### PR TITLE
Revert LF on committing before applying copyright

### DIFF
--- a/.stagedstylelintrc
+++ b/.stagedstylelintrc
@@ -1,8 +1,0 @@
-{
-  "extends": [
-    "./.stylelintrc"
-  ],
-  "rules": {
-    "prettier/prettier": true,
-  }
-}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
       "prettier --write --config .prettierrc --ignore-path .prettierignore"
     ],
     "*.{scss,css}": [
-      "stylelint --fix --config .stagedstylelintrc --allow-empty-input",
+      "stylelint --fix --config .stylelintrc --allow-empty-input",
       "node ./scripts/copyright-linter.js --"
     ]
   },

--- a/scripts/copyright-linter.js
+++ b/scripts/copyright-linter.js
@@ -1,3 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 const fs = require("fs");
 
 //get all arguments after the positional argument indicator, "--"
@@ -10,10 +14,10 @@ const filePaths = process.argv.reduce((acc, cur) => {
   }
 }, false);
 
-const copyrightBanner = `/*---------------------------------------------------------------------------------------------\n* Copyright (c) Bentley Systems, Incorporated. All rights reserved.\n* See LICENSE.md in the project root for license terms and full copyright notice.\n*--------------------------------------------------------------------------------------------*/`;
+const copyrightBanner = `/*---------------------------------------------------------------------------------------------\n * Copyright (c) Bentley Systems, Incorporated. All rights reserved.\n * See LICENSE.md in the project root for license terms and full copyright notice.\n *--------------------------------------------------------------------------------------------*/`;
 
-const longCopyright = "/?/[*](.|\n)*?Copyright(.|\n)*?[*]/";
-const shortCopyright = "//\\s*Copyright.*\n";
+const longCopyright = "/?/[*](.|\r?\n)*?Copyright(.|\r?\n)*?[*]/\r?\n";
+const shortCopyright = "//\\s*Copyright.*\r?\n";
 const oldCopyrightBanner = RegExp(
   `^(${longCopyright})|(${shortCopyright})`,
   "m"


### PR DESCRIPTION
Windows machines that pull CRLF files were causing SCSS file copyright header to be duplicated because the script did not recognise the "startWith" properly when file is CRLF instead of LF. 

Now stylelint will use prettier fix, like we do for the typescript files, to fix that issue before the copyright header is applied.