### PR TITLE
Create only 1 connection and update APIs

### DIFF
--- a/packages/app/src/api/storage/api.ts
+++ b/packages/app/src/api/storage/api.ts
@@ -22,10 +22,7 @@ import * as url from "url";
 
 import { Configuration } from "./configuration";
 
-export const BASE_PATH = "https://api.bentley.com/storage/v1".replace(
-  /\/+$/,
-  ""
-);
+export const BASE_PATH = "https://api.bentley.com/storage".replace(/\/+$/, "");
 
 /**
  *
@@ -93,15 +90,21 @@ export class RequiredError extends Error {
 /**
  *
  * @export
- * @interface Errors
+ * @interface Error
  */
-export interface Errors {
+export interface Error {
   /**
    *
-   * @type {Array<any>}
-   * @memberof Errors
+   * @type {string}
+   * @memberof Error
    */
-  errors?: Array<any>;
+  message?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof Error
+   */
+  code?: string;
 }
 
 /**
@@ -180,28 +183,14 @@ export interface File {
 export interface FileCreate {
   /**
    *
-   * @type {FileCreateDetails}
-   * @memberof FileCreate
-   */
-  file?: FileCreateDetails;
-}
-
-/**
- *
- * @export
- * @interface FileCreateDetails
- */
-export interface FileCreateDetails {
-  /**
-   *
    * @type {string}
-   * @memberof FileCreateDetails
+   * @memberof FileCreate
    */
   displayName?: string;
   /**
    *
    * @type {string}
-   * @memberof FileCreateDetails
+   * @memberof FileCreate
    */
   description?: string;
 }
@@ -209,15 +198,15 @@ export interface FileCreateDetails {
 /**
  *
  * @export
- * @interface FileCreated
+ * @interface FileResult
  */
-export interface FileCreated {
+export interface FileResult {
   /**
    *
-   * @type {any}
-   * @memberof FileCreated
+   * @type {FileTyped}
+   * @memberof FileResult
    */
-  file?: any;
+  file?: FileTyped;
 }
 
 /**
@@ -292,6 +281,26 @@ export interface FileTyped {
    * @memberof FileTyped
    */
   parentFolderId?: string;
+}
+
+/**
+ *
+ * @export
+ * @interface FileUpdate
+ */
+export interface FileUpdate {
+  /**
+   *
+   * @type {string}
+   * @memberof FileUpdate
+   */
+  displayName?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof FileUpdate
+   */
+  description?: string;
 }
 
 /**
@@ -398,28 +407,14 @@ export interface Folder {
 export interface FolderCreate {
   /**
    *
-   * @type {FolderCreateDetails}
-   * @memberof FolderCreate
-   */
-  folder?: FolderCreateDetails;
-}
-
-/**
- *
- * @export
- * @interface FolderCreateDetails
- */
-export interface FolderCreateDetails {
-  /**
-   *
    * @type {string}
-   * @memberof FolderCreateDetails
+   * @memberof FolderCreate
    */
   displayName?: string;
   /**
    *
    * @type {string}
-   * @memberof FolderCreateDetails
+   * @memberof FolderCreate
    */
   description?: string;
 }
@@ -427,15 +422,15 @@ export interface FolderCreateDetails {
 /**
  *
  * @export
- * @interface FolderCreated
+ * @interface FolderResult
  */
-export interface FolderCreated {
+export interface FolderResult {
   /**
    *
-   * @type {Folder}
-   * @memberof FolderCreated
+   * @type {FolderTyped}
+   * @memberof FolderResult
    */
-  folder?: Folder;
+  folder?: FolderTyped;
 }
 
 /**
@@ -504,6 +499,26 @@ export interface FolderTyped {
    * @memberof FolderTyped
    */
   parentFolderId?: string;
+}
+
+/**
+ *
+ * @export
+ * @interface FolderUpdate
+ */
+export interface FolderUpdate {
+  /**
+   *
+   * @type {string}
+   * @memberof FolderUpdate
+   */
+  displayName?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof FolderUpdate
+   */
+  description?: string;
 }
 
 /**
@@ -607,6 +622,20 @@ export interface LinksUpload {
 }
 
 /**
+ *
+ * @export
+ * @interface MinimalError
+ */
+export interface MinimalError {
+  /**
+   *
+   * @type {Error}
+   * @memberof MinimalError
+   */
+  self?: Error;
+}
+
+/**
  * FilesApi - fetch parameter creator
  * @export
  */
@@ -615,11 +644,11 @@ export const FilesApiFetchParamCreator = function(
 ) {
   return {
     /**
-     * ---    Complete file creation    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Complete file creation    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Complete file creation
      * @param {string} fileId File Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -711,12 +740,12 @@ export const FilesApiFetchParamCreator = function(
       };
     },
     /**
-     * ---    Create new file    ### Notes    File creation is three steps operation. This request will create file's meta data. Next two requests need to be executed by using links from the response.    - uploadUrl is required for file upload. Upload can be done by sending http request and specifying x-ms-blob-type header to BlockBlob.  - completeUrl should be used to confirm file upload and it is final request for file creation.    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ### Errors    This request can return InvalidCreateFileRequest error with 422 status code. This could happen because of these reasons:    - File name contains invalid characters.  - File name's length is larger than 255 characters.  - File could be harmful. For example, executable files are not accepted.    ---
+     * ---    Create new file    ### Notes    File creation is three steps operation. This request will create file's meta data. Next two requests need to be executed by using links from the response.    - uploadUrl is required for file upload. Upload can be done by sending http request and specifying x-ms-blob-type header to BlockBlob.  - completeUrl should be used to confirm file upload and it is final request for file creation.    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ### Errors    This request can return InvalidCreateFileRequest error with 422 status code. This could happen because of these reasons:    - File name contains invalid characters.  - File name's length is larger than 255 characters.  - File could be harmful. For example, executable files are not accepted.    ---
      * @summary Create file
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
-     * @param {FileCreate} [file__create]
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+     * @param {FileCreate} [file_create]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -724,7 +753,7 @@ export const FilesApiFetchParamCreator = function(
       folderId: string,
       Authorization: string,
       Accept?: "application/vnd.bentley.itwin-platform.v1+json",
-      file__create?: FileCreate,
+      file_create?: FileCreate,
       options: any = {}
     ): FetchArgs {
       // verify required parameter 'folderId' is not null or undefined
@@ -808,8 +837,8 @@ export const FilesApiFetchParamCreator = function(
         <any>"FileCreate" !== "string" ||
         localVarRequestOptions.headers["Content-Type"] === "application/json";
       localVarRequestOptions.body = needsSerialization
-        ? JSON.stringify(file__create || {})
-        : file__create || "";
+        ? JSON.stringify(file_create || {})
+        : file_create || "";
 
       return {
         url: url.format(localVarUrlObj),
@@ -817,11 +846,11 @@ export const FilesApiFetchParamCreator = function(
       };
     },
     /**
-     * ---    Delete a file    ### Notes    File moved to the recycle bin will be completely removed after 30 days.    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Delete a file    ### Notes    File moved to the recycle bin will be completely removed after 30 days.    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Delete file
      * @param {string} fileId File Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -916,11 +945,11 @@ export const FilesApiFetchParamCreator = function(
       };
     },
     /**
-     * ---    Delete a file from the recycle bin    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Delete a file from the recycle bin    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Delete file from recycle bin
      * @param {string} fileId File Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -1015,11 +1044,11 @@ export const FilesApiFetchParamCreator = function(
       };
     },
     /**
-     * ---    Retrieves file    ### Notes    This endpoint returns 302 status code with Location header, which on success contains a link to the file. Redirection is not supported by developer portal and an error could be returned while using the \"Try it\" feature for this API. However, this endpoint will work if a request is sent from a different http client or by using the link specified in the response Location header.    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves file    ### Notes    This endpoint returns 302 status code with Location header, which on success contains a link to the file. Redirection is not supported by developer portal and an error could be returned while using the \"Try it\" feature for this API. However, this endpoint will work if a request is sent from a different http client or by using the link specified in the response Location header.    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Download file
      * @param {string} fileId File Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -1111,11 +1140,11 @@ export const FilesApiFetchParamCreator = function(
       };
     },
     /**
-     * ---    Retrieves file    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves file    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get file
      * @param {string} fileId File Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -1207,13 +1236,13 @@ export const FilesApiFetchParamCreator = function(
       };
     },
     /**
-     * ---    Retrieves files    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves files    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get files in folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -1315,13 +1344,13 @@ export const FilesApiFetchParamCreator = function(
       };
     },
     /**
-     * ---    Retrieves files and folders    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves files and folders    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get folders and files in folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -1423,13 +1452,13 @@ export const FilesApiFetchParamCreator = function(
       };
     },
     /**
-     * ---    Get deleted files and folders    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Get deleted files and folders    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get folders and files in recycle bin
      * @param {string} projectId Project Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -1532,11 +1561,120 @@ export const FilesApiFetchParamCreator = function(
       };
     },
     /**
-     * ---    Restore deleted file from the recycle bin    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Retrieves top level files and folders by project    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
+     * @summary Get top level folders and files by project
+     * @param {string} projectId Project Id
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
+     * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
+     * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getTopLevelFoldersAndFilesByProject(
+      projectId: string,
+      Authorization: string,
+      top?: number,
+      skip?: number,
+      Accept?: "application/vnd.bentley.itwin-platform.v1+json",
+      options: any = {}
+    ): FetchArgs {
+      // verify required parameter 'projectId' is not null or undefined
+      if (projectId === null || projectId === undefined) {
+        throw new RequiredError(
+          "projectId",
+          "Required parameter projectId was null or undefined when calling getTopLevelFoldersAndFilesByProject."
+        );
+      }
+      // verify required parameter 'Authorization' is not null or undefined
+      if (Authorization === null || Authorization === undefined) {
+        throw new RequiredError(
+          "Authorization",
+          "Required parameter Authorization was null or undefined when calling getTopLevelFoldersAndFilesByProject."
+        );
+      }
+      const localVarPath = `/`;
+      const localVarUrlObj = url.parse(localVarPath, true);
+      const localVarRequestOptions = Object.assign({ method: "GET" }, options);
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication apiKeyHeader required
+      if (configuration && configuration.apiKey) {
+        const localVarApiKeyValue =
+          typeof configuration.apiKey === "function"
+            ? configuration.apiKey("X-Api-Subscription-Key")
+            : configuration.apiKey;
+        localVarHeaderParameter["X-Api-Subscription-Key"] = localVarApiKeyValue;
+      }
+
+      // authentication apiKeyQuery required
+      if (configuration && configuration.apiKey) {
+        const localVarApiKeyValue =
+          typeof configuration.apiKey === "function"
+            ? configuration.apiKey("apikey")
+            : configuration.apiKey;
+        localVarQueryParameter["apikey"] = localVarApiKeyValue;
+      }
+
+      // authentication oauth2Bentley OAuth2 Service required
+      // oauth required
+      if (configuration && configuration.accessToken) {
+        const localVarAccessTokenValue =
+          typeof configuration.accessToken === "function"
+            ? configuration.accessToken("oauth2Bentley OAuth2 Service", [
+                "storage:read storage:modify",
+              ])
+            : configuration.accessToken;
+        localVarHeaderParameter["Authorization"] =
+          "Bearer " + localVarAccessTokenValue;
+      }
+
+      if (projectId !== undefined) {
+        localVarQueryParameter["projectId"] = projectId;
+      }
+
+      if (top !== undefined) {
+        localVarQueryParameter["$top"] = top;
+      }
+
+      if (skip !== undefined) {
+        localVarQueryParameter["$skip"] = skip;
+      }
+
+      if (Authorization !== undefined && Authorization !== null) {
+        localVarHeaderParameter["Authorization"] = String(Authorization);
+      }
+
+      if (Accept !== undefined && Accept !== null) {
+        localVarHeaderParameter["Accept"] = String(Accept);
+      }
+
+      localVarUrlObj.query = Object.assign(
+        {},
+        localVarUrlObj.query,
+        localVarQueryParameter,
+        options.query
+      );
+      // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+      delete localVarUrlObj.search;
+      localVarRequestOptions.headers = Object.assign(
+        {},
+        localVarHeaderParameter,
+        options.headers
+      );
+
+      return {
+        url: url.format(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * ---    Restore deleted file from the recycle bin    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Restore file
      * @param {string} fileId File Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -1628,14 +1766,14 @@ export const FilesApiFetchParamCreator = function(
       };
     },
     /**
-     * ---    Finds files and folders in folder by name    ### Notes    This query supports wildcard characters in the name parameter    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Finds files and folders in folder by name    ### Notes    This query supports wildcard characters in the name parameter    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Search for folders and files in folder
      * @param {string} folderId Folder Id
      * @param {string} name Item name
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -1748,6 +1886,115 @@ export const FilesApiFetchParamCreator = function(
         options: localVarRequestOptions,
       };
     },
+    /**
+     * ---    Update file    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ### Errors    This request can return InvalidCreateFileRequest error with 422 status code. This could happen because of these reasons:    - File name contains invalid characters.  - File name's length is larger than 255 characters.  - File could be harmful. For example, executable files are not accepted.    ---
+     * @summary Update file
+     * @param {string} fileId File Id
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+     * @param {FileUpdate} [file_update]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    updateFile(
+      fileId: string,
+      Authorization: string,
+      Accept?: "application/vnd.bentley.itwin-platform.v1+json",
+      file_update?: FileUpdate,
+      options: any = {}
+    ): FetchArgs {
+      // verify required parameter 'fileId' is not null or undefined
+      if (fileId === null || fileId === undefined) {
+        throw new RequiredError(
+          "fileId",
+          "Required parameter fileId was null or undefined when calling updateFile."
+        );
+      }
+      // verify required parameter 'Authorization' is not null or undefined
+      if (Authorization === null || Authorization === undefined) {
+        throw new RequiredError(
+          "Authorization",
+          "Required parameter Authorization was null or undefined when calling updateFile."
+        );
+      }
+      const localVarPath = `/files/{fileId}`.replace(
+        `{${"fileId"}}`,
+        encodeURIComponent(String(fileId))
+      );
+      const localVarUrlObj = url.parse(localVarPath, true);
+      const localVarRequestOptions = Object.assign(
+        { method: "PATCH" },
+        options
+      );
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication apiKeyHeader required
+      if (configuration && configuration.apiKey) {
+        const localVarApiKeyValue =
+          typeof configuration.apiKey === "function"
+            ? configuration.apiKey("X-Api-Subscription-Key")
+            : configuration.apiKey;
+        localVarHeaderParameter["X-Api-Subscription-Key"] = localVarApiKeyValue;
+      }
+
+      // authentication apiKeyQuery required
+      if (configuration && configuration.apiKey) {
+        const localVarApiKeyValue =
+          typeof configuration.apiKey === "function"
+            ? configuration.apiKey("apikey")
+            : configuration.apiKey;
+        localVarQueryParameter["apikey"] = localVarApiKeyValue;
+      }
+
+      // authentication oauth2Bentley OAuth2 Service required
+      // oauth required
+      if (configuration && configuration.accessToken) {
+        const localVarAccessTokenValue =
+          typeof configuration.accessToken === "function"
+            ? configuration.accessToken("oauth2Bentley OAuth2 Service", [
+                "storage:read storage:modify",
+              ])
+            : configuration.accessToken;
+        localVarHeaderParameter["Authorization"] =
+          "Bearer " + localVarAccessTokenValue;
+      }
+
+      if (Authorization !== undefined && Authorization !== null) {
+        localVarHeaderParameter["Authorization"] = String(Authorization);
+      }
+
+      if (Accept !== undefined && Accept !== null) {
+        localVarHeaderParameter["Accept"] = String(Accept);
+      }
+
+      localVarHeaderParameter["Content-Type"] = "application/json";
+
+      localVarUrlObj.query = Object.assign(
+        {},
+        localVarUrlObj.query,
+        localVarQueryParameter,
+        options.query
+      );
+      // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+      delete localVarUrlObj.search;
+      localVarRequestOptions.headers = Object.assign(
+        {},
+        localVarHeaderParameter,
+        options.headers
+      );
+      const needsSerialization =
+        <any>"FileUpdate" !== "string" ||
+        localVarRequestOptions.headers["Content-Type"] === "application/json";
+      localVarRequestOptions.body = needsSerialization
+        ? JSON.stringify(file_update || {})
+        : file_update || "";
+
+      return {
+        url: url.format(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
   };
 };
 
@@ -1758,11 +2005,11 @@ export const FilesApiFetchParamCreator = function(
 export const FilesApiFp = function(configuration?: Configuration) {
   return {
     /**
-     * ---    Complete file creation    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Complete file creation    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Complete file creation
      * @param {string} fileId File Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -1771,7 +2018,7 @@ export const FilesApiFp = function(configuration?: Configuration) {
       Authorization: string,
       Accept?: "application/vnd.bentley.itwin-platform.v1+json",
       options?: any
-    ): (fetch?: FetchAPI, basePath?: string) => Promise<FileCreated> {
+    ): (fetch?: FetchAPI, basePath?: string) => Promise<FileResult> {
       const localVarFetchArgs = FilesApiFetchParamCreator(
         configuration
       ).completeFileCreation(fileId, Authorization, Accept, options);
@@ -1792,12 +2039,12 @@ export const FilesApiFp = function(configuration?: Configuration) {
       };
     },
     /**
-     * ---    Create new file    ### Notes    File creation is three steps operation. This request will create file's meta data. Next two requests need to be executed by using links from the response.    - uploadUrl is required for file upload. Upload can be done by sending http request and specifying x-ms-blob-type header to BlockBlob.  - completeUrl should be used to confirm file upload and it is final request for file creation.    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ### Errors    This request can return InvalidCreateFileRequest error with 422 status code. This could happen because of these reasons:    - File name contains invalid characters.  - File name's length is larger than 255 characters.  - File could be harmful. For example, executable files are not accepted.    ---
+     * ---    Create new file    ### Notes    File creation is three steps operation. This request will create file's meta data. Next two requests need to be executed by using links from the response.    - uploadUrl is required for file upload. Upload can be done by sending http request and specifying x-ms-blob-type header to BlockBlob.  - completeUrl should be used to confirm file upload and it is final request for file creation.    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ### Errors    This request can return InvalidCreateFileRequest error with 422 status code. This could happen because of these reasons:    - File name contains invalid characters.  - File name's length is larger than 255 characters.  - File could be harmful. For example, executable files are not accepted.    ---
      * @summary Create file
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
-     * @param {FileCreate} [file__create]
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+     * @param {FileCreate} [file_create]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -1805,12 +2052,12 @@ export const FilesApiFp = function(configuration?: Configuration) {
       folderId: string,
       Authorization: string,
       Accept?: "application/vnd.bentley.itwin-platform.v1+json",
-      file__create?: FileCreate,
+      file_create?: FileCreate,
       options?: any
     ): (fetch?: FetchAPI, basePath?: string) => Promise<FileUpload> {
       const localVarFetchArgs = FilesApiFetchParamCreator(
         configuration
-      ).createFile(folderId, Authorization, Accept, file__create, options);
+      ).createFile(folderId, Authorization, Accept, file_create, options);
       return (
         fetch: FetchAPI = portableFetch,
         basePath: string = BASE_PATH
@@ -1828,11 +2075,11 @@ export const FilesApiFp = function(configuration?: Configuration) {
       };
     },
     /**
-     * ---    Delete a file    ### Notes    File moved to the recycle bin will be completely removed after 30 days.    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Delete a file    ### Notes    File moved to the recycle bin will be completely removed after 30 days.    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Delete file
      * @param {string} fileId File Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -1862,11 +2109,11 @@ export const FilesApiFp = function(configuration?: Configuration) {
       };
     },
     /**
-     * ---    Delete a file from the recycle bin    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Delete a file from the recycle bin    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Delete file from recycle bin
      * @param {string} fileId File Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -1896,11 +2143,11 @@ export const FilesApiFp = function(configuration?: Configuration) {
       };
     },
     /**
-     * ---    Retrieves file    ### Notes    This endpoint returns 302 status code with Location header, which on success contains a link to the file. Redirection is not supported by developer portal and an error could be returned while using the \"Try it\" feature for this API. However, this endpoint will work if a request is sent from a different http client or by using the link specified in the response Location header.    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves file    ### Notes    This endpoint returns 302 status code with Location header, which on success contains a link to the file. Redirection is not supported by developer portal and an error could be returned while using the \"Try it\" feature for this API. However, this endpoint will work if a request is sent from a different http client or by using the link specified in the response Location header.    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Download file
      * @param {string} fileId File Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -1930,11 +2177,11 @@ export const FilesApiFp = function(configuration?: Configuration) {
       };
     },
     /**
-     * ---    Retrieves file    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves file    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get file
      * @param {string} fileId File Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -1943,7 +2190,7 @@ export const FilesApiFp = function(configuration?: Configuration) {
       Authorization: string,
       Accept?: "application/vnd.bentley.itwin-platform.v1+json",
       options?: any
-    ): (fetch?: FetchAPI, basePath?: string) => Promise<any> {
+    ): (fetch?: FetchAPI, basePath?: string) => Promise<FileResult> {
       const localVarFetchArgs = FilesApiFetchParamCreator(
         configuration
       ).getFile(fileId, Authorization, Accept, options);
@@ -1964,13 +2211,13 @@ export const FilesApiFp = function(configuration?: Configuration) {
       };
     },
     /**
-     * ---    Retrieves files    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves files    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get files in folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -2002,13 +2249,13 @@ export const FilesApiFp = function(configuration?: Configuration) {
       };
     },
     /**
-     * ---    Retrieves files and folders    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves files and folders    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get folders and files in folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -2047,13 +2294,13 @@ export const FilesApiFp = function(configuration?: Configuration) {
       };
     },
     /**
-     * ---    Get deleted files and folders    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Get deleted files and folders    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get folders and files in recycle bin
      * @param {string} projectId Project Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -2092,11 +2339,56 @@ export const FilesApiFp = function(configuration?: Configuration) {
       };
     },
     /**
-     * ---    Restore deleted file from the recycle bin    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Retrieves top level files and folders by project    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
+     * @summary Get top level folders and files by project
+     * @param {string} projectId Project Id
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
+     * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
+     * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getTopLevelFoldersAndFilesByProject(
+      projectId: string,
+      Authorization: string,
+      top?: number,
+      skip?: number,
+      Accept?: "application/vnd.bentley.itwin-platform.v1+json",
+      options?: any
+    ): (fetch?: FetchAPI, basePath?: string) => Promise<Items> {
+      const localVarFetchArgs = FilesApiFetchParamCreator(
+        configuration
+      ).getTopLevelFoldersAndFilesByProject(
+        projectId,
+        Authorization,
+        top,
+        skip,
+        Accept,
+        options
+      );
+      return (
+        fetch: FetchAPI = portableFetch,
+        basePath: string = BASE_PATH
+      ) => {
+        return fetch(
+          basePath + localVarFetchArgs.url,
+          localVarFetchArgs.options
+        ).then((response) => {
+          if (response.status >= 200 && response.status < 300) {
+            return response.json();
+          } else {
+            throw response;
+          }
+        });
+      };
+    },
+    /**
+     * ---    Restore deleted file from the recycle bin    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Restore file
      * @param {string} fileId File Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -2126,14 +2418,14 @@ export const FilesApiFp = function(configuration?: Configuration) {
       };
     },
     /**
-     * ---    Finds files and folders in folder by name    ### Notes    This query supports wildcard characters in the name parameter    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Finds files and folders in folder by name    ### Notes    This query supports wildcard characters in the name parameter    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Search for folders and files in folder
      * @param {string} folderId Folder Id
      * @param {string} name Item name
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -2173,6 +2465,42 @@ export const FilesApiFp = function(configuration?: Configuration) {
         });
       };
     },
+    /**
+     * ---    Update file    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ### Errors    This request can return InvalidCreateFileRequest error with 422 status code. This could happen because of these reasons:    - File name contains invalid characters.  - File name's length is larger than 255 characters.  - File could be harmful. For example, executable files are not accepted.    ---
+     * @summary Update file
+     * @param {string} fileId File Id
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+     * @param {FileUpdate} [file_update]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    updateFile(
+      fileId: string,
+      Authorization: string,
+      Accept?: "application/vnd.bentley.itwin-platform.v1+json",
+      file_update?: FileUpdate,
+      options?: any
+    ): (fetch?: FetchAPI, basePath?: string) => Promise<FileResult> {
+      const localVarFetchArgs = FilesApiFetchParamCreator(
+        configuration
+      ).updateFile(fileId, Authorization, Accept, file_update, options);
+      return (
+        fetch: FetchAPI = portableFetch,
+        basePath: string = BASE_PATH
+      ) => {
+        return fetch(
+          basePath + localVarFetchArgs.url,
+          localVarFetchArgs.options
+        ).then((response) => {
+          if (response.status >= 200 && response.status < 300) {
+            return response.json();
+          } else {
+            throw response;
+          }
+        });
+      };
+    },
   };
 };
 
@@ -2187,11 +2515,11 @@ export const FilesApiFactory = function(
 ) {
   return {
     /**
-     * ---    Complete file creation    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Complete file creation    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Complete file creation
      * @param {string} fileId File Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -2209,12 +2537,12 @@ export const FilesApiFactory = function(
       )(fetch, basePath);
     },
     /**
-     * ---    Create new file    ### Notes    File creation is three steps operation. This request will create file's meta data. Next two requests need to be executed by using links from the response.    - uploadUrl is required for file upload. Upload can be done by sending http request and specifying x-ms-blob-type header to BlockBlob.  - completeUrl should be used to confirm file upload and it is final request for file creation.    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ### Errors    This request can return InvalidCreateFileRequest error with 422 status code. This could happen because of these reasons:    - File name contains invalid characters.  - File name's length is larger than 255 characters.  - File could be harmful. For example, executable files are not accepted.    ---
+     * ---    Create new file    ### Notes    File creation is three steps operation. This request will create file's meta data. Next two requests need to be executed by using links from the response.    - uploadUrl is required for file upload. Upload can be done by sending http request and specifying x-ms-blob-type header to BlockBlob.  - completeUrl should be used to confirm file upload and it is final request for file creation.    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ### Errors    This request can return InvalidCreateFileRequest error with 422 status code. This could happen because of these reasons:    - File name contains invalid characters.  - File name's length is larger than 255 characters.  - File could be harmful. For example, executable files are not accepted.    ---
      * @summary Create file
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
-     * @param {FileCreate} [file__create]
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+     * @param {FileCreate} [file_create]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -2222,23 +2550,23 @@ export const FilesApiFactory = function(
       folderId: string,
       Authorization: string,
       Accept?: "application/vnd.bentley.itwin-platform.v1+json",
-      file__create?: FileCreate,
+      file_create?: FileCreate,
       options?: any
     ) {
       return FilesApiFp(configuration).createFile(
         folderId,
         Authorization,
         Accept,
-        file__create,
+        file_create,
         options
       )(fetch, basePath);
     },
     /**
-     * ---    Delete a file    ### Notes    File moved to the recycle bin will be completely removed after 30 days.    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Delete a file    ### Notes    File moved to the recycle bin will be completely removed after 30 days.    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Delete file
      * @param {string} fileId File Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -2256,11 +2584,11 @@ export const FilesApiFactory = function(
       )(fetch, basePath);
     },
     /**
-     * ---    Delete a file from the recycle bin    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Delete a file from the recycle bin    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Delete file from recycle bin
      * @param {string} fileId File Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -2278,11 +2606,11 @@ export const FilesApiFactory = function(
       )(fetch, basePath);
     },
     /**
-     * ---    Retrieves file    ### Notes    This endpoint returns 302 status code with Location header, which on success contains a link to the file. Redirection is not supported by developer portal and an error could be returned while using the \"Try it\" feature for this API. However, this endpoint will work if a request is sent from a different http client or by using the link specified in the response Location header.    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves file    ### Notes    This endpoint returns 302 status code with Location header, which on success contains a link to the file. Redirection is not supported by developer portal and an error could be returned while using the \"Try it\" feature for this API. However, this endpoint will work if a request is sent from a different http client or by using the link specified in the response Location header.    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Download file
      * @param {string} fileId File Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -2300,11 +2628,11 @@ export const FilesApiFactory = function(
       )(fetch, basePath);
     },
     /**
-     * ---    Retrieves file    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves file    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get file
      * @param {string} fileId File Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -2322,13 +2650,13 @@ export const FilesApiFactory = function(
       )(fetch, basePath);
     },
     /**
-     * ---    Retrieves files    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves files    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get files in folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -2350,13 +2678,13 @@ export const FilesApiFactory = function(
       )(fetch, basePath);
     },
     /**
-     * ---    Retrieves files and folders    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves files and folders    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get folders and files in folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -2378,13 +2706,13 @@ export const FilesApiFactory = function(
       )(fetch, basePath);
     },
     /**
-     * ---    Get deleted files and folders    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Get deleted files and folders    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get folders and files in recycle bin
      * @param {string} projectId Project Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -2406,11 +2734,39 @@ export const FilesApiFactory = function(
       )(fetch, basePath);
     },
     /**
-     * ---    Restore deleted file from the recycle bin    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Retrieves top level files and folders by project    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
+     * @summary Get top level folders and files by project
+     * @param {string} projectId Project Id
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
+     * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
+     * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getTopLevelFoldersAndFilesByProject(
+      projectId: string,
+      Authorization: string,
+      top?: number,
+      skip?: number,
+      Accept?: "application/vnd.bentley.itwin-platform.v1+json",
+      options?: any
+    ) {
+      return FilesApiFp(configuration).getTopLevelFoldersAndFilesByProject(
+        projectId,
+        Authorization,
+        top,
+        skip,
+        Accept,
+        options
+      )(fetch, basePath);
+    },
+    /**
+     * ---    Restore deleted file from the recycle bin    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Restore file
      * @param {string} fileId File Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -2428,14 +2784,14 @@ export const FilesApiFactory = function(
       )(fetch, basePath);
     },
     /**
-     * ---    Finds files and folders in folder by name    ### Notes    This query supports wildcard characters in the name parameter    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Finds files and folders in folder by name    ### Notes    This query supports wildcard characters in the name parameter    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Search for folders and files in folder
      * @param {string} folderId Folder Id
      * @param {string} name Item name
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -2458,6 +2814,31 @@ export const FilesApiFactory = function(
         options
       )(fetch, basePath);
     },
+    /**
+     * ---    Update file    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ### Errors    This request can return InvalidCreateFileRequest error with 422 status code. This could happen because of these reasons:    - File name contains invalid characters.  - File name's length is larger than 255 characters.  - File could be harmful. For example, executable files are not accepted.    ---
+     * @summary Update file
+     * @param {string} fileId File Id
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+     * @param {FileUpdate} [file_update]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    updateFile(
+      fileId: string,
+      Authorization: string,
+      Accept?: "application/vnd.bentley.itwin-platform.v1+json",
+      file_update?: FileUpdate,
+      options?: any
+    ) {
+      return FilesApiFp(configuration).updateFile(
+        fileId,
+        Authorization,
+        Accept,
+        file_update,
+        options
+      )(fetch, basePath);
+    },
   };
 };
 
@@ -2469,11 +2850,11 @@ export const FilesApiFactory = function(
  */
 export class FilesApi extends BaseAPI {
   /**
-   * ---    Complete file creation    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+   * ---    Complete file creation    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
    * @summary Complete file creation
    * @param {string} fileId File Id
-   * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof FilesApi
@@ -2493,12 +2874,12 @@ export class FilesApi extends BaseAPI {
   }
 
   /**
-   * ---    Create new file    ### Notes    File creation is three steps operation. This request will create file's meta data. Next two requests need to be executed by using links from the response.    - uploadUrl is required for file upload. Upload can be done by sending http request and specifying x-ms-blob-type header to BlockBlob.  - completeUrl should be used to confirm file upload and it is final request for file creation.    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ### Errors    This request can return InvalidCreateFileRequest error with 422 status code. This could happen because of these reasons:    - File name contains invalid characters.  - File name's length is larger than 255 characters.  - File could be harmful. For example, executable files are not accepted.    ---
+   * ---    Create new file    ### Notes    File creation is three steps operation. This request will create file's meta data. Next two requests need to be executed by using links from the response.    - uploadUrl is required for file upload. Upload can be done by sending http request and specifying x-ms-blob-type header to BlockBlob.  - completeUrl should be used to confirm file upload and it is final request for file creation.    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ### Errors    This request can return InvalidCreateFileRequest error with 422 status code. This could happen because of these reasons:    - File name contains invalid characters.  - File name's length is larger than 255 characters.  - File could be harmful. For example, executable files are not accepted.    ---
    * @summary Create file
    * @param {string} folderId Folder Id
-   * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
-   * @param {FileCreate} [file__create]
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+   * @param {FileCreate} [file_create]
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof FilesApi
@@ -2507,24 +2888,24 @@ export class FilesApi extends BaseAPI {
     folderId: string,
     Authorization: string,
     Accept?: "application/vnd.bentley.itwin-platform.v1+json",
-    file__create?: FileCreate,
+    file_create?: FileCreate,
     options?: any
   ) {
     return FilesApiFp(this.configuration).createFile(
       folderId,
       Authorization,
       Accept,
-      file__create,
+      file_create,
       options
     )(this.fetch, this.basePath);
   }
 
   /**
-   * ---    Delete a file    ### Notes    File moved to the recycle bin will be completely removed after 30 days.    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+   * ---    Delete a file    ### Notes    File moved to the recycle bin will be completely removed after 30 days.    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
    * @summary Delete file
    * @param {string} fileId File Id
-   * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof FilesApi
@@ -2544,11 +2925,11 @@ export class FilesApi extends BaseAPI {
   }
 
   /**
-   * ---    Delete a file from the recycle bin    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+   * ---    Delete a file from the recycle bin    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
    * @summary Delete file from recycle bin
    * @param {string} fileId File Id
-   * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof FilesApi
@@ -2568,11 +2949,11 @@ export class FilesApi extends BaseAPI {
   }
 
   /**
-   * ---    Retrieves file    ### Notes    This endpoint returns 302 status code with Location header, which on success contains a link to the file. Redirection is not supported by developer portal and an error could be returned while using the \"Try it\" feature for this API. However, this endpoint will work if a request is sent from a different http client or by using the link specified in the response Location header.    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+   * ---    Retrieves file    ### Notes    This endpoint returns 302 status code with Location header, which on success contains a link to the file. Redirection is not supported by developer portal and an error could be returned while using the \"Try it\" feature for this API. However, this endpoint will work if a request is sent from a different http client or by using the link specified in the response Location header.    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
    * @summary Download file
    * @param {string} fileId File Id
-   * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
-   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof FilesApi
@@ -2592,11 +2973,11 @@ export class FilesApi extends BaseAPI {
   }
 
   /**
-   * ---    Retrieves file    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+   * ---    Retrieves file    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
    * @summary Get file
    * @param {string} fileId File Id
-   * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
-   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof FilesApi
@@ -2616,13 +2997,13 @@ export class FilesApi extends BaseAPI {
   }
 
   /**
-   * ---    Retrieves files    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+   * ---    Retrieves files    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
    * @summary Get files in folder
    * @param {string} folderId Folder Id
-   * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
    * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
    * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof FilesApi
@@ -2646,13 +3027,13 @@ export class FilesApi extends BaseAPI {
   }
 
   /**
-   * ---    Retrieves files and folders    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+   * ---    Retrieves files and folders    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
    * @summary Get folders and files in folder
    * @param {string} folderId Folder Id
-   * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
    * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
    * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof FilesApi
@@ -2676,13 +3057,13 @@ export class FilesApi extends BaseAPI {
   }
 
   /**
-   * ---    Get deleted files and folders    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+   * ---    Get deleted files and folders    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
    * @summary Get folders and files in recycle bin
    * @param {string} projectId Project Id
-   * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
    * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
    * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof FilesApi
@@ -2706,11 +3087,41 @@ export class FilesApi extends BaseAPI {
   }
 
   /**
-   * ---    Restore deleted file from the recycle bin    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+   * ---    Retrieves top level files and folders by project    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
+   * @summary Get top level folders and files by project
+   * @param {string} projectId Project Id
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
+   * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
+   * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof FilesApi
+   */
+  public getTopLevelFoldersAndFilesByProject(
+    projectId: string,
+    Authorization: string,
+    top?: number,
+    skip?: number,
+    Accept?: "application/vnd.bentley.itwin-platform.v1+json",
+    options?: any
+  ) {
+    return FilesApiFp(this.configuration).getTopLevelFoldersAndFilesByProject(
+      projectId,
+      Authorization,
+      top,
+      skip,
+      Accept,
+      options
+    )(this.fetch, this.basePath);
+  }
+
+  /**
+   * ---    Restore deleted file from the recycle bin    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
    * @summary Restore file
    * @param {string} fileId File Id
-   * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof FilesApi
@@ -2730,14 +3141,14 @@ export class FilesApi extends BaseAPI {
   }
 
   /**
-   * ---    Finds files and folders in folder by name    ### Notes    This query supports wildcard characters in the name parameter    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+   * ---    Finds files and folders in folder by name    ### Notes    This query supports wildcard characters in the name parameter    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
    * @summary Search for folders and files in folder
    * @param {string} folderId Folder Id
    * @param {string} name Item name
-   * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
    * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
    * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
-   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof FilesApi
@@ -2761,6 +3172,33 @@ export class FilesApi extends BaseAPI {
       options
     )(this.fetch, this.basePath);
   }
+
+  /**
+   * ---    Update file    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ### Errors    This request can return InvalidCreateFileRequest error with 422 status code. This could happen because of these reasons:    - File name contains invalid characters.  - File name's length is larger than 255 characters.  - File could be harmful. For example, executable files are not accepted.    ---
+   * @summary Update file
+   * @param {string} fileId File Id
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+   * @param {FileUpdate} [file_update]
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof FilesApi
+   */
+  public updateFile(
+    fileId: string,
+    Authorization: string,
+    Accept?: "application/vnd.bentley.itwin-platform.v1+json",
+    file_update?: FileUpdate,
+    options?: any
+  ) {
+    return FilesApiFp(this.configuration).updateFile(
+      fileId,
+      Authorization,
+      Accept,
+      file_update,
+      options
+    )(this.fetch, this.basePath);
+  }
 }
 
 /**
@@ -2772,12 +3210,12 @@ export const FoldersApiFetchParamCreator = function(
 ) {
   return {
     /**
-     * ---    Create new folder    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ### Errors    This request can return InvalidCreateFolderRequest error with 422 status code. This could happen because of these reasons:    - Folder name contains invalid characters.  - Folder name's length is larger than 255 characters.    ---
+     * ---    Create new folder    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ### Errors    This request can return InvalidCreateFolderRequest error with 422 status code. This could happen because of these reasons:    - Folder name contains invalid characters.  - Folder name's length is larger than 255 characters.    ---
      * @summary Create folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
-     * @param {FolderCreate} [folder__create]
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+     * @param {FolderCreate} [folder_create]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -2785,7 +3223,7 @@ export const FoldersApiFetchParamCreator = function(
       folderId: string,
       Authorization: string,
       Accept?: "application/vnd.bentley.itwin-platform.v1+json",
-      folder__create?: FolderCreate,
+      folder_create?: FolderCreate,
       options: any = {}
     ): FetchArgs {
       // verify required parameter 'folderId' is not null or undefined
@@ -2869,8 +3307,8 @@ export const FoldersApiFetchParamCreator = function(
         <any>"FolderCreate" !== "string" ||
         localVarRequestOptions.headers["Content-Type"] === "application/json";
       localVarRequestOptions.body = needsSerialization
-        ? JSON.stringify(folder__create || {})
-        : folder__create || "";
+        ? JSON.stringify(folder_create || {})
+        : folder_create || "";
 
       return {
         url: url.format(localVarUrlObj),
@@ -2878,11 +3316,11 @@ export const FoldersApiFetchParamCreator = function(
       };
     },
     /**
-     * ---    Delete a folder    ### Notes    Folder moved to the recycle bin will be completely removed after 30 days.    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Delete a folder    ### Notes    Folder moved to the recycle bin will be completely removed after 30 days.    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Delete folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -2977,11 +3415,11 @@ export const FoldersApiFetchParamCreator = function(
       };
     },
     /**
-     * ---    Delete a folder from the recycle bin    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Delete a folder from the recycle bin    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Delete folder from recycle bin
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -3076,11 +3514,11 @@ export const FoldersApiFetchParamCreator = function(
       };
     },
     /**
-     * ---    Retrieves folder    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves folder    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -3172,13 +3610,13 @@ export const FoldersApiFetchParamCreator = function(
       };
     },
     /**
-     * ---    Retrieves files and folders    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves files and folders    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get folders and files in folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -3280,13 +3718,13 @@ export const FoldersApiFetchParamCreator = function(
       };
     },
     /**
-     * ---    Get deleted files and folders    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Get deleted files and folders    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get folders and files in recycle bin
      * @param {string} projectId Project Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -3389,13 +3827,13 @@ export const FoldersApiFetchParamCreator = function(
       };
     },
     /**
-     * ---    Retrieves folders    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves folders    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get folders in folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -3497,11 +3935,120 @@ export const FoldersApiFetchParamCreator = function(
       };
     },
     /**
-     * ---    Restore deleted folder from the recycle bin    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Retrieves top level files and folders by project    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
+     * @summary Get top level folders and files by project
+     * @param {string} projectId Project Id
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
+     * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
+     * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getTopLevelFoldersAndFilesByProject(
+      projectId: string,
+      Authorization: string,
+      top?: number,
+      skip?: number,
+      Accept?: "application/vnd.bentley.itwin-platform.v1+json",
+      options: any = {}
+    ): FetchArgs {
+      // verify required parameter 'projectId' is not null or undefined
+      if (projectId === null || projectId === undefined) {
+        throw new RequiredError(
+          "projectId",
+          "Required parameter projectId was null or undefined when calling getTopLevelFoldersAndFilesByProject."
+        );
+      }
+      // verify required parameter 'Authorization' is not null or undefined
+      if (Authorization === null || Authorization === undefined) {
+        throw new RequiredError(
+          "Authorization",
+          "Required parameter Authorization was null or undefined when calling getTopLevelFoldersAndFilesByProject."
+        );
+      }
+      const localVarPath = `/`;
+      const localVarUrlObj = url.parse(localVarPath, true);
+      const localVarRequestOptions = Object.assign({ method: "GET" }, options);
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication apiKeyHeader required
+      if (configuration && configuration.apiKey) {
+        const localVarApiKeyValue =
+          typeof configuration.apiKey === "function"
+            ? configuration.apiKey("X-Api-Subscription-Key")
+            : configuration.apiKey;
+        localVarHeaderParameter["X-Api-Subscription-Key"] = localVarApiKeyValue;
+      }
+
+      // authentication apiKeyQuery required
+      if (configuration && configuration.apiKey) {
+        const localVarApiKeyValue =
+          typeof configuration.apiKey === "function"
+            ? configuration.apiKey("apikey")
+            : configuration.apiKey;
+        localVarQueryParameter["apikey"] = localVarApiKeyValue;
+      }
+
+      // authentication oauth2Bentley OAuth2 Service required
+      // oauth required
+      if (configuration && configuration.accessToken) {
+        const localVarAccessTokenValue =
+          typeof configuration.accessToken === "function"
+            ? configuration.accessToken("oauth2Bentley OAuth2 Service", [
+                "storage:read storage:modify",
+              ])
+            : configuration.accessToken;
+        localVarHeaderParameter["Authorization"] =
+          "Bearer " + localVarAccessTokenValue;
+      }
+
+      if (projectId !== undefined) {
+        localVarQueryParameter["projectId"] = projectId;
+      }
+
+      if (top !== undefined) {
+        localVarQueryParameter["$top"] = top;
+      }
+
+      if (skip !== undefined) {
+        localVarQueryParameter["$skip"] = skip;
+      }
+
+      if (Authorization !== undefined && Authorization !== null) {
+        localVarHeaderParameter["Authorization"] = String(Authorization);
+      }
+
+      if (Accept !== undefined && Accept !== null) {
+        localVarHeaderParameter["Accept"] = String(Accept);
+      }
+
+      localVarUrlObj.query = Object.assign(
+        {},
+        localVarUrlObj.query,
+        localVarQueryParameter,
+        options.query
+      );
+      // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+      delete localVarUrlObj.search;
+      localVarRequestOptions.headers = Object.assign(
+        {},
+        localVarHeaderParameter,
+        options.headers
+      );
+
+      return {
+        url: url.format(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * ---    Restore deleted folder from the recycle bin    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Restore folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -3593,14 +4140,14 @@ export const FoldersApiFetchParamCreator = function(
       };
     },
     /**
-     * ---    Finds files and folders in folder by name    ### Notes    This query supports wildcard characters in the name parameter    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Finds files and folders in folder by name    ### Notes    This query supports wildcard characters in the name parameter    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Search for folders and files in folder
      * @param {string} folderId Folder Id
      * @param {string} name Item name
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -3713,6 +4260,115 @@ export const FoldersApiFetchParamCreator = function(
         options: localVarRequestOptions,
       };
     },
+    /**
+     * ---    Update folder    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ### Errors    This request can return InvalidCreateFolderRequest error with 422 status code. This could happen because of these reasons:    - Folder name contains invalid characters.  - Folder name's length is larger than 255 characters.    ---
+     * @summary Update folder
+     * @param {string} folderId Folder Id
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+     * @param {FolderUpdate} [folder_update]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    updateFolder(
+      folderId: string,
+      Authorization: string,
+      Accept?: "application/vnd.bentley.itwin-platform.v1+json",
+      folder_update?: FolderUpdate,
+      options: any = {}
+    ): FetchArgs {
+      // verify required parameter 'folderId' is not null or undefined
+      if (folderId === null || folderId === undefined) {
+        throw new RequiredError(
+          "folderId",
+          "Required parameter folderId was null or undefined when calling updateFolder."
+        );
+      }
+      // verify required parameter 'Authorization' is not null or undefined
+      if (Authorization === null || Authorization === undefined) {
+        throw new RequiredError(
+          "Authorization",
+          "Required parameter Authorization was null or undefined when calling updateFolder."
+        );
+      }
+      const localVarPath = `/folders/{folderId}`.replace(
+        `{${"folderId"}}`,
+        encodeURIComponent(String(folderId))
+      );
+      const localVarUrlObj = url.parse(localVarPath, true);
+      const localVarRequestOptions = Object.assign(
+        { method: "PATCH" },
+        options
+      );
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication apiKeyHeader required
+      if (configuration && configuration.apiKey) {
+        const localVarApiKeyValue =
+          typeof configuration.apiKey === "function"
+            ? configuration.apiKey("X-Api-Subscription-Key")
+            : configuration.apiKey;
+        localVarHeaderParameter["X-Api-Subscription-Key"] = localVarApiKeyValue;
+      }
+
+      // authentication apiKeyQuery required
+      if (configuration && configuration.apiKey) {
+        const localVarApiKeyValue =
+          typeof configuration.apiKey === "function"
+            ? configuration.apiKey("apikey")
+            : configuration.apiKey;
+        localVarQueryParameter["apikey"] = localVarApiKeyValue;
+      }
+
+      // authentication oauth2Bentley OAuth2 Service required
+      // oauth required
+      if (configuration && configuration.accessToken) {
+        const localVarAccessTokenValue =
+          typeof configuration.accessToken === "function"
+            ? configuration.accessToken("oauth2Bentley OAuth2 Service", [
+                "storage:read storage:modify",
+              ])
+            : configuration.accessToken;
+        localVarHeaderParameter["Authorization"] =
+          "Bearer " + localVarAccessTokenValue;
+      }
+
+      if (Authorization !== undefined && Authorization !== null) {
+        localVarHeaderParameter["Authorization"] = String(Authorization);
+      }
+
+      if (Accept !== undefined && Accept !== null) {
+        localVarHeaderParameter["Accept"] = String(Accept);
+      }
+
+      localVarHeaderParameter["Content-Type"] = "application/json";
+
+      localVarUrlObj.query = Object.assign(
+        {},
+        localVarUrlObj.query,
+        localVarQueryParameter,
+        options.query
+      );
+      // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+      delete localVarUrlObj.search;
+      localVarRequestOptions.headers = Object.assign(
+        {},
+        localVarHeaderParameter,
+        options.headers
+      );
+      const needsSerialization =
+        <any>"FolderUpdate" !== "string" ||
+        localVarRequestOptions.headers["Content-Type"] === "application/json";
+      localVarRequestOptions.body = needsSerialization
+        ? JSON.stringify(folder_update || {})
+        : folder_update || "";
+
+      return {
+        url: url.format(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
   };
 };
 
@@ -3723,12 +4379,12 @@ export const FoldersApiFetchParamCreator = function(
 export const FoldersApiFp = function(configuration?: Configuration) {
   return {
     /**
-     * ---    Create new folder    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ### Errors    This request can return InvalidCreateFolderRequest error with 422 status code. This could happen because of these reasons:    - Folder name contains invalid characters.  - Folder name's length is larger than 255 characters.    ---
+     * ---    Create new folder    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ### Errors    This request can return InvalidCreateFolderRequest error with 422 status code. This could happen because of these reasons:    - Folder name contains invalid characters.  - Folder name's length is larger than 255 characters.    ---
      * @summary Create folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
-     * @param {FolderCreate} [folder__create]
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+     * @param {FolderCreate} [folder_create]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -3736,12 +4392,12 @@ export const FoldersApiFp = function(configuration?: Configuration) {
       folderId: string,
       Authorization: string,
       Accept?: "application/vnd.bentley.itwin-platform.v1+json",
-      folder__create?: FolderCreate,
+      folder_create?: FolderCreate,
       options?: any
-    ): (fetch?: FetchAPI, basePath?: string) => Promise<FolderCreated> {
+    ): (fetch?: FetchAPI, basePath?: string) => Promise<FolderResult> {
       const localVarFetchArgs = FoldersApiFetchParamCreator(
         configuration
-      ).createFolder(folderId, Authorization, Accept, folder__create, options);
+      ).createFolder(folderId, Authorization, Accept, folder_create, options);
       return (
         fetch: FetchAPI = portableFetch,
         basePath: string = BASE_PATH
@@ -3759,11 +4415,11 @@ export const FoldersApiFp = function(configuration?: Configuration) {
       };
     },
     /**
-     * ---    Delete a folder    ### Notes    Folder moved to the recycle bin will be completely removed after 30 days.    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Delete a folder    ### Notes    Folder moved to the recycle bin will be completely removed after 30 days.    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Delete folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -3793,11 +4449,11 @@ export const FoldersApiFp = function(configuration?: Configuration) {
       };
     },
     /**
-     * ---    Delete a folder from the recycle bin    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Delete a folder from the recycle bin    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Delete folder from recycle bin
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -3827,11 +4483,11 @@ export const FoldersApiFp = function(configuration?: Configuration) {
       };
     },
     /**
-     * ---    Retrieves folder    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves folder    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -3861,13 +4517,13 @@ export const FoldersApiFp = function(configuration?: Configuration) {
       };
     },
     /**
-     * ---    Retrieves files and folders    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves files and folders    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get folders and files in folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -3906,13 +4562,13 @@ export const FoldersApiFp = function(configuration?: Configuration) {
       };
     },
     /**
-     * ---    Get deleted files and folders    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Get deleted files and folders    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get folders and files in recycle bin
      * @param {string} projectId Project Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -3951,13 +4607,13 @@ export const FoldersApiFp = function(configuration?: Configuration) {
       };
     },
     /**
-     * ---    Retrieves folders    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves folders    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get folders in folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -3989,11 +4645,56 @@ export const FoldersApiFp = function(configuration?: Configuration) {
       };
     },
     /**
-     * ---    Restore deleted folder from the recycle bin    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Retrieves top level files and folders by project    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
+     * @summary Get top level folders and files by project
+     * @param {string} projectId Project Id
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
+     * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
+     * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getTopLevelFoldersAndFilesByProject(
+      projectId: string,
+      Authorization: string,
+      top?: number,
+      skip?: number,
+      Accept?: "application/vnd.bentley.itwin-platform.v1+json",
+      options?: any
+    ): (fetch?: FetchAPI, basePath?: string) => Promise<Items> {
+      const localVarFetchArgs = FoldersApiFetchParamCreator(
+        configuration
+      ).getTopLevelFoldersAndFilesByProject(
+        projectId,
+        Authorization,
+        top,
+        skip,
+        Accept,
+        options
+      );
+      return (
+        fetch: FetchAPI = portableFetch,
+        basePath: string = BASE_PATH
+      ) => {
+        return fetch(
+          basePath + localVarFetchArgs.url,
+          localVarFetchArgs.options
+        ).then((response) => {
+          if (response.status >= 200 && response.status < 300) {
+            return response.json();
+          } else {
+            throw response;
+          }
+        });
+      };
+    },
+    /**
+     * ---    Restore deleted folder from the recycle bin    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Restore folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -4023,14 +4724,14 @@ export const FoldersApiFp = function(configuration?: Configuration) {
       };
     },
     /**
-     * ---    Finds files and folders in folder by name    ### Notes    This query supports wildcard characters in the name parameter    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Finds files and folders in folder by name    ### Notes    This query supports wildcard characters in the name parameter    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Search for folders and files in folder
      * @param {string} folderId Folder Id
      * @param {string} name Item name
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -4070,6 +4771,42 @@ export const FoldersApiFp = function(configuration?: Configuration) {
         });
       };
     },
+    /**
+     * ---    Update folder    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ### Errors    This request can return InvalidCreateFolderRequest error with 422 status code. This could happen because of these reasons:    - Folder name contains invalid characters.  - Folder name's length is larger than 255 characters.    ---
+     * @summary Update folder
+     * @param {string} folderId Folder Id
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+     * @param {FolderUpdate} [folder_update]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    updateFolder(
+      folderId: string,
+      Authorization: string,
+      Accept?: "application/vnd.bentley.itwin-platform.v1+json",
+      folder_update?: FolderUpdate,
+      options?: any
+    ): (fetch?: FetchAPI, basePath?: string) => Promise<FolderResult> {
+      const localVarFetchArgs = FoldersApiFetchParamCreator(
+        configuration
+      ).updateFolder(folderId, Authorization, Accept, folder_update, options);
+      return (
+        fetch: FetchAPI = portableFetch,
+        basePath: string = BASE_PATH
+      ) => {
+        return fetch(
+          basePath + localVarFetchArgs.url,
+          localVarFetchArgs.options
+        ).then((response) => {
+          if (response.status >= 200 && response.status < 300) {
+            return response.json();
+          } else {
+            throw response;
+          }
+        });
+      };
+    },
   };
 };
 
@@ -4084,12 +4821,12 @@ export const FoldersApiFactory = function(
 ) {
   return {
     /**
-     * ---    Create new folder    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ### Errors    This request can return InvalidCreateFolderRequest error with 422 status code. This could happen because of these reasons:    - Folder name contains invalid characters.  - Folder name's length is larger than 255 characters.    ---
+     * ---    Create new folder    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ### Errors    This request can return InvalidCreateFolderRequest error with 422 status code. This could happen because of these reasons:    - Folder name contains invalid characters.  - Folder name's length is larger than 255 characters.    ---
      * @summary Create folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
-     * @param {FolderCreate} [folder__create]
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+     * @param {FolderCreate} [folder_create]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -4097,23 +4834,23 @@ export const FoldersApiFactory = function(
       folderId: string,
       Authorization: string,
       Accept?: "application/vnd.bentley.itwin-platform.v1+json",
-      folder__create?: FolderCreate,
+      folder_create?: FolderCreate,
       options?: any
     ) {
       return FoldersApiFp(configuration).createFolder(
         folderId,
         Authorization,
         Accept,
-        folder__create,
+        folder_create,
         options
       )(fetch, basePath);
     },
     /**
-     * ---    Delete a folder    ### Notes    Folder moved to the recycle bin will be completely removed after 30 days.    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Delete a folder    ### Notes    Folder moved to the recycle bin will be completely removed after 30 days.    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Delete folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -4131,11 +4868,11 @@ export const FoldersApiFactory = function(
       )(fetch, basePath);
     },
     /**
-     * ---    Delete a folder from the recycle bin    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Delete a folder from the recycle bin    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Delete folder from recycle bin
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -4153,11 +4890,11 @@ export const FoldersApiFactory = function(
       )(fetch, basePath);
     },
     /**
-     * ---    Retrieves folder    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves folder    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -4175,13 +4912,13 @@ export const FoldersApiFactory = function(
       )(fetch, basePath);
     },
     /**
-     * ---    Retrieves files and folders    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves files and folders    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get folders and files in folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -4203,13 +4940,13 @@ export const FoldersApiFactory = function(
       )(fetch, basePath);
     },
     /**
-     * ---    Get deleted files and folders    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Get deleted files and folders    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get folders and files in recycle bin
      * @param {string} projectId Project Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -4231,13 +4968,13 @@ export const FoldersApiFactory = function(
       )(fetch, basePath);
     },
     /**
-     * ---    Retrieves folders    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Retrieves folders    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Get folders in folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -4259,11 +4996,39 @@ export const FoldersApiFactory = function(
       )(fetch, basePath);
     },
     /**
-     * ---    Restore deleted folder from the recycle bin    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+     * ---    Retrieves top level files and folders by project    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
+     * @summary Get top level folders and files by project
+     * @param {string} projectId Project Id
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
+     * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
+     * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getTopLevelFoldersAndFilesByProject(
+      projectId: string,
+      Authorization: string,
+      top?: number,
+      skip?: number,
+      Accept?: "application/vnd.bentley.itwin-platform.v1+json",
+      options?: any
+    ) {
+      return FoldersApiFp(configuration).getTopLevelFoldersAndFilesByProject(
+        projectId,
+        Authorization,
+        top,
+        skip,
+        Accept,
+        options
+      )(fetch, basePath);
+    },
+    /**
+     * ---    Restore deleted folder from the recycle bin    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
      * @summary Restore folder
      * @param {string} folderId Folder Id
-     * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -4281,14 +5046,14 @@ export const FoldersApiFactory = function(
       )(fetch, basePath);
     },
     /**
-     * ---    Finds files and folders in folder by name    ### Notes    This query supports wildcard characters in the name parameter    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+     * ---    Finds files and folders in folder by name    ### Notes    This query supports wildcard characters in the name parameter    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
      * @summary Search for folders and files in folder
      * @param {string} folderId Folder Id
      * @param {string} name Item name
-     * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
      * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
      * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
-     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -4311,6 +5076,31 @@ export const FoldersApiFactory = function(
         options
       )(fetch, basePath);
     },
+    /**
+     * ---    Update folder    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ### Errors    This request can return InvalidCreateFolderRequest error with 422 status code. This could happen because of these reasons:    - Folder name contains invalid characters.  - Folder name's length is larger than 255 characters.    ---
+     * @summary Update folder
+     * @param {string} folderId Folder Id
+     * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+     * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+     * @param {FolderUpdate} [folder_update]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    updateFolder(
+      folderId: string,
+      Authorization: string,
+      Accept?: "application/vnd.bentley.itwin-platform.v1+json",
+      folder_update?: FolderUpdate,
+      options?: any
+    ) {
+      return FoldersApiFp(configuration).updateFolder(
+        folderId,
+        Authorization,
+        Accept,
+        folder_update,
+        options
+      )(fetch, basePath);
+    },
   };
 };
 
@@ -4322,12 +5112,12 @@ export const FoldersApiFactory = function(
  */
 export class FoldersApi extends BaseAPI {
   /**
-   * ---    Create new folder    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ### Errors    This request can return InvalidCreateFolderRequest error with 422 status code. This could happen because of these reasons:    - Folder name contains invalid characters.  - Folder name's length is larger than 255 characters.    ---
+   * ---    Create new folder    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ### Errors    This request can return InvalidCreateFolderRequest error with 422 status code. This could happen because of these reasons:    - Folder name contains invalid characters.  - Folder name's length is larger than 255 characters.    ---
    * @summary Create folder
    * @param {string} folderId Folder Id
-   * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
-   * @param {FolderCreate} [folder__create]
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+   * @param {FolderCreate} [folder_create]
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof FoldersApi
@@ -4336,24 +5126,24 @@ export class FoldersApi extends BaseAPI {
     folderId: string,
     Authorization: string,
     Accept?: "application/vnd.bentley.itwin-platform.v1+json",
-    folder__create?: FolderCreate,
+    folder_create?: FolderCreate,
     options?: any
   ) {
     return FoldersApiFp(this.configuration).createFolder(
       folderId,
       Authorization,
       Accept,
-      folder__create,
+      folder_create,
       options
     )(this.fetch, this.basePath);
   }
 
   /**
-   * ---    Delete a folder    ### Notes    Folder moved to the recycle bin will be completely removed after 30 days.    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+   * ---    Delete a folder    ### Notes    Folder moved to the recycle bin will be completely removed after 30 days.    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
    * @summary Delete folder
    * @param {string} folderId Folder Id
-   * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof FoldersApi
@@ -4373,11 +5163,11 @@ export class FoldersApi extends BaseAPI {
   }
 
   /**
-   * ---    Delete a folder from the recycle bin    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+   * ---    Delete a folder from the recycle bin    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
    * @summary Delete folder from recycle bin
    * @param {string} folderId Folder Id
-   * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof FoldersApi
@@ -4397,11 +5187,11 @@ export class FoldersApi extends BaseAPI {
   }
 
   /**
-   * ---    Retrieves folder    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+   * ---    Retrieves folder    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
    * @summary Get folder
    * @param {string} folderId Folder Id
-   * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
-   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof FoldersApi
@@ -4421,13 +5211,13 @@ export class FoldersApi extends BaseAPI {
   }
 
   /**
-   * ---    Retrieves files and folders    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+   * ---    Retrieves files and folders    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
    * @summary Get folders and files in folder
    * @param {string} folderId Folder Id
-   * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
    * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
    * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof FoldersApi
@@ -4451,13 +5241,13 @@ export class FoldersApi extends BaseAPI {
   }
 
   /**
-   * ---    Get deleted files and folders    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+   * ---    Get deleted files and folders    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
    * @summary Get folders and files in recycle bin
    * @param {string} projectId Project Id
-   * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
    * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
    * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof FoldersApi
@@ -4481,13 +5271,13 @@ export class FoldersApi extends BaseAPI {
   }
 
   /**
-   * ---    Retrieves folders    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+   * ---    Retrieves folders    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
    * @summary Get folders in folder
    * @param {string} folderId Folder Id
-   * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
    * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
    * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
-   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof FoldersApi
@@ -4511,11 +5301,41 @@ export class FoldersApi extends BaseAPI {
   }
 
   /**
-   * ---    Restore deleted folder from the recycle bin    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:modify*.    ---
+   * ---    Retrieves top level files and folders by project    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
+   * @summary Get top level folders and files by project
+   * @param {string} projectId Project Id
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
+   * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
+   * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof FoldersApi
+   */
+  public getTopLevelFoldersAndFilesByProject(
+    projectId: string,
+    Authorization: string,
+    top?: number,
+    skip?: number,
+    Accept?: "application/vnd.bentley.itwin-platform.v1+json",
+    options?: any
+  ) {
+    return FoldersApiFp(this.configuration).getTopLevelFoldersAndFilesByProject(
+      projectId,
+      Authorization,
+      top,
+      skip,
+      Accept,
+      options
+    )(this.fetch, this.basePath);
+  }
+
+  /**
+   * ---    Restore deleted folder from the recycle bin    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ---
    * @summary Restore folder
    * @param {string} folderId Folder Id
-   * @param {string} Authorization OAuth access token with scope &#39;storage:modify&#39;
-   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof FoldersApi
@@ -4535,14 +5355,14 @@ export class FoldersApi extends BaseAPI {
   }
 
   /**
-   * ---    Finds files and folders in folder by name    ### Notes    This query supports wildcard characters in the name parameter    ### Authentication    Requires *Authorization* header with valid Bearer token for scope *storage:read*.    ---
+   * ---    Finds files and folders in folder by name    ### Notes    This query supports wildcard characters in the name parameter    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:read`.    ---
    * @summary Search for folders and files in folder
    * @param {string} folderId Folder Id
    * @param {string} name Item name
-   * @param {string} Authorization OAuth access token with scope &#39;storage:read&#39;
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:read&#x60;
    * @param {number} [skip] The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.
    * @param {number} [top] The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.
-   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof FoldersApi
@@ -4563,6 +5383,33 @@ export class FoldersApi extends BaseAPI {
       skip,
       top,
       Accept,
+      options
+    )(this.fetch, this.basePath);
+  }
+
+  /**
+   * ---    Update folder    ### Authentication    Requires `Authorization` header with valid Bearer token for scope `storage:modify`.    ### Errors    This request can return InvalidCreateFolderRequest error with 422 status code. This could happen because of these reasons:    - Folder name contains invalid characters.  - Folder name's length is larger than 255 characters.    ---
+   * @summary Update folder
+   * @param {string} folderId Folder Id
+   * @param {string} Authorization OAuth access token with scope &#x60;storage:modify&#x60;
+   * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] Setting to &#x60;application/vnd.bentley.itwin-platform.v1+json&#x60; is recommended.
+   * @param {FolderUpdate} [folder_update]
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof FoldersApi
+   */
+  public updateFolder(
+    folderId: string,
+    Authorization: string,
+    Accept?: "application/vnd.bentley.itwin-platform.v1+json",
+    folder_update?: FolderUpdate,
+    options?: any
+  ) {
+    return FoldersApiFp(this.configuration).updateFolder(
+      folderId,
+      Authorization,
+      Accept,
+      folder_update,
       options
     )(this.fetch, this.basePath);
   }

--- a/packages/app/src/api/storageApiUtils.ts
+++ b/packages/app/src/api/storageApiUtils.ts
@@ -2,7 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { FilesApiFp, FoldersApi } from "../../api/storage";
+import { FilesApiFp, FoldersApi } from "./storage";
+
+const DEMO_FOLDER_NAME = "demo-portal-imodel-connections";
 
 export const extractFolderIdFromStorageHref = (href?: string) => {
   return href?.split("/").reverse()?.[0] ?? "";
@@ -26,7 +28,7 @@ export const getDemoFolderId = async (
 ) => {
   return getFolderIdByName(
     projectFolderId,
-    "demo-portal-imodel-connections",
+    DEMO_FOLDER_NAME,
     accessToken,
     createIfNotFound,
     api
@@ -82,7 +84,8 @@ const getFolderIdByName = async (
       folderId,
       accessToken,
       pageSize,
-      currentPage * pageSize
+      currentPage * pageSize,
+      "application/vnd.bentley.itwin-platform.v1+json"
     );
     namedFolderId =
       folders.folders?.find((folder) => folder.displayName === folderName)
@@ -97,13 +100,11 @@ const getFolderIdByName = async (
     const namedFolder = await api.createFolder(
       folderId,
       accessToken,
-      undefined,
+      "application/vnd.bentley.itwin-platform.v1+json",
       {
-        folder: {
-          displayName: folderName,
-          description:
-            "Folder used by the Demo portal to store iModel automatic iModel creation",
-        },
+        displayName: folderName,
+        description:
+          "Folder used by the Demo portal to store iModel automatic iModel creation",
       }
     );
     namedFolderId = namedFolder.folder?.id ?? "";

--- a/packages/app/src/api/storageOpenAPI.json
+++ b/packages/app/src/api/storageOpenAPI.json
@@ -6,7 +6,7 @@
     "description": "Storage API allowing quick files managing"
   },
   "host": "api.bentley.com",
-  "basePath": "/storage/v1",
+  "basePath": "/storage",
   "schemes": ["https"],
   "securityDefinitions": {
     "apiKeyHeader": {
@@ -40,131 +40,9 @@
     }
   ],
   "paths": {
-    "/recycleBin/folders/{folderId}/restore": {
-      "post": {
-        "description": "---\r\n\r\nRestore deleted folder from the recycle bin\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:modify*.\r\n\r\n---",
-        "operationId": "restore-folder",
-        "summary": "Restore folder",
-        "tags": ["Folders"],
-        "parameters": [
-          {
-            "name": "folderId",
-            "in": "path",
-            "description": "Folder Id",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "OAuth access token with scope 'storage:modify'",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Accept",
-            "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
-            "type": "string",
-            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
-          }
-        ],
-        "produces": ["application/json"],
-        "responses": {
-          "204": {
-            "description": "A folder was restored successfully."
-          },
-          "401": {
-            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
-            "examples": {
-              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
-            }
-          },
-          "404": {
-            "description": "Folder cannot be found.",
-            "examples": {
-              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FolderNotFound\",\r\n    \"message\": \"Requested folder not available.\"\r\n  }\r\n}"
-            }
-          },
-          "429": {
-            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
-            "headers": {
-              "retry-after": {
-                "type": "string",
-                "description": "The number of requests exceeds the rate-limit for the client subscription."
-              }
-            },
-            "examples": {
-              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
-            }
-          }
-        }
-      }
-    },
-    "/recycleBin/files/{fileId}": {
-      "delete": {
-        "description": "---\r\n\r\nDelete a file from the recycle bin\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:modify*.\r\n\r\n---",
-        "operationId": "delete-file-from-recycle-bin",
-        "summary": "Delete file from recycle bin",
-        "tags": ["Files"],
-        "parameters": [
-          {
-            "name": "fileId",
-            "in": "path",
-            "description": "File Id",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "OAuth access token with scope 'storage:modify'",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Accept",
-            "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
-            "type": "string",
-            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
-          }
-        ],
-        "produces": ["application/json"],
-        "responses": {
-          "204": {
-            "description": "A file was deleted successfully."
-          },
-          "401": {
-            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
-            "examples": {
-              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
-            }
-          },
-          "404": {
-            "description": "File cannot be found.",
-            "examples": {
-              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FileNotFound\",\r\n    \"message\": \"Requested file not available.\"\r\n  }\r\n}"
-            }
-          },
-          "429": {
-            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
-            "headers": {
-              "retry-after": {
-                "type": "string",
-                "description": "The number of requests exceeds the rate-limit for the client subscription."
-              }
-            },
-            "examples": {
-              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
-            }
-          }
-        }
-      }
-    },
     "/files/{fileId}/download": {
       "get": {
-        "description": "---\r\n\r\nRetrieves file\r\n\r\n### Notes\r\n\r\nThis endpoint returns 302 status code with Location header, which on success contains a link to the file. Redirection is not supported by developer portal and an error could be returned while using the \"Try it\" feature for this API. However, this endpoint will work if a request is sent from a different http client or by using the link specified in the response Location header.\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:read*.\r\n\r\n---",
+        "description": "---\r\n\r\nRetrieves file\r\n\r\n### Notes\r\n\r\nThis endpoint returns 302 status code with Location header, which on success contains a link to the file. Redirection is not supported by developer portal and an error could be returned while using the \"Try it\" feature for this API. However, this endpoint will work if a request is sent from a different http client or by using the link specified in the response Location header.\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:read`.\r\n\r\n---",
         "operationId": "download-file",
         "summary": "Download file",
         "tags": ["Files"],
@@ -179,14 +57,14 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:read'",
+            "description": "OAuth access token with scope `storage:read`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           }
@@ -225,7 +103,7 @@
     },
     "/recycleBin/folders/{folderId}": {
       "delete": {
-        "description": "---\r\n\r\nDelete a folder from the recycle bin\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:modify*.\r\n\r\n---",
+        "description": "---\r\n\r\nDelete a folder from the recycle bin\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n---",
         "operationId": "delete-folder-from-recycle-bin",
         "summary": "Delete folder from recycle bin",
         "tags": ["Folders"],
@@ -240,14 +118,14 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:modify'",
+            "description": "OAuth access token with scope `storage:modify`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           }
@@ -286,7 +164,7 @@
     },
     "/recycleBin/files/{fileId}/restore": {
       "post": {
-        "description": "---\r\n\r\nRestore deleted file from the recycle bin\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:modify*.\r\n\r\n---",
+        "description": "---\r\n\r\nRestore deleted file from the recycle bin\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n---",
         "operationId": "restore-file",
         "summary": "Restore file",
         "tags": ["Files"],
@@ -301,14 +179,14 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:modify'",
+            "description": "OAuth access token with scope `storage:modify`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           }
@@ -345,135 +223,9 @@
         }
       }
     },
-    "/files/{fileId}": {
-      "delete": {
-        "description": "---\r\n\r\nDelete a file\r\n\r\n### Notes\r\n\r\nFile moved to the recycle bin will be completely removed after 30 days.\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:modify*.\r\n\r\n---",
-        "operationId": "delete-file",
-        "summary": "Delete file",
-        "tags": ["Files"],
-        "parameters": [
-          {
-            "name": "fileId",
-            "in": "path",
-            "description": "File Id",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "OAuth access token with scope 'storage:modify'",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Accept",
-            "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
-            "type": "string",
-            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
-          }
-        ],
-        "produces": ["application/json"],
-        "responses": {
-          "204": {
-            "description": "A file was deleted successfully."
-          },
-          "401": {
-            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
-            "examples": {
-              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
-            }
-          },
-          "404": {
-            "description": "File cannot be found.",
-            "examples": {
-              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FileNotFound\",\r\n    \"message\": \"Requested file not available.\"\r\n  }\r\n}"
-            }
-          },
-          "429": {
-            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
-            "headers": {
-              "retry-after": {
-                "type": "string",
-                "description": "The number of requests exceeds the rate-limit for the client subscription."
-              }
-            },
-            "examples": {
-              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
-            }
-          }
-        }
-      },
-      "get": {
-        "description": "---\r\n\r\nRetrieves file\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:read*.\r\n\r\n---",
-        "operationId": "get-file",
-        "summary": "Get file",
-        "tags": ["Files"],
-        "parameters": [
-          {
-            "name": "fileId",
-            "in": "path",
-            "description": "File Id",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "OAuth access token with scope 'storage:read'",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Accept",
-            "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
-            "type": "string",
-            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
-          }
-        ],
-        "produces": ["application/json"],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/file"
-            },
-            "examples": {
-              "application/json": "{\r\n  \"file\": {\r\n    \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n    \"displayName\": \"file.txt\",\r\n    \"description\": \"test file\",\r\n    \"path\": \"folderName/file.txt\",\r\n    \"size\": 1,\r\n    \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"lastModifiedDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n  }\r\n}\r\n"
-            }
-          },
-          "401": {
-            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
-            "examples": {
-              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
-            }
-          },
-          "404": {
-            "description": "File cannot be found.",
-            "examples": {
-              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FileNotFound\",\r\n    \"message\": \"Requested file not available.\"\r\n  }\r\n}"
-            }
-          },
-          "429": {
-            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
-            "headers": {
-              "retry-after": {
-                "type": "string",
-                "description": "The number of requests exceeds the rate-limit for the client subscription."
-              }
-            },
-            "examples": {
-              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
-            }
-          }
-        }
-      }
-    },
     "/folders/{folderId}": {
       "delete": {
-        "description": "---\r\n\r\nDelete a folder\r\n\r\n### Notes\r\n\r\nFolder moved to the recycle bin will be completely removed after 30 days.\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:modify*.\r\n\r\n---",
+        "description": "---\r\n\r\nDelete a folder\r\n\r\n### Notes\r\n\r\nFolder moved to the recycle bin will be completely removed after 30 days.\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n---",
         "operationId": "delete-folder",
         "summary": "Delete folder",
         "tags": ["Folders"],
@@ -488,14 +240,14 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:modify'",
+            "description": "OAuth access token with scope `storage:modify`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           }
@@ -532,7 +284,7 @@
         }
       },
       "get": {
-        "description": "---\r\n\r\nRetrieves folder\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:read*.\r\n\r\n---",
+        "description": "---\r\n\r\nRetrieves folder\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:read`.\r\n\r\n---",
         "operationId": "get-folder",
         "summary": "Get folder",
         "tags": ["Folders"],
@@ -547,14 +299,14 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:read'",
+            "description": "OAuth access token with scope `storage:read`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           }
@@ -595,13 +347,153 @@
             }
           }
         }
+      },
+      "patch": {
+        "description": "---\r\n\r\nUpdate folder\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n### Errors\r\n\r\nThis request can return InvalidCreateFolderRequest error with 422 status code. This could happen because of these reasons:\r\n\r\n- Folder name contains invalid characters.\r\n- Folder name's length is larger than 255 characters.\r\n\r\n---\r\n",
+        "operationId": "update-folder",
+        "summary": "Update folder",
+        "tags": ["Folders"],
+        "parameters": [
+          {
+            "name": "folderId",
+            "in": "path",
+            "description": "Folder Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "OAuth access token with scope `storage:modify`",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
+            "type": "string",
+            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
+          },
+          {
+            "name": "folder-update",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/folder-update"
+            }
+          }
+        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/folder-result"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"folder\": {\r\n    \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n    \"displayName\": \"test\",\r\n    \"description\": \"test folder\",\r\n    \"path\": \"folderName/test\",\r\n    \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"lastModifiedDateTime\": \"2021-05-15T12:07:06.7841448Z\",\r\n    \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n  }\r\n}\r\n"
+            }
+          },
+          "401": {
+            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
+            "examples": {
+              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
+            }
+          },
+          "404": {
+            "description": "Parent folder cannot be found.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FolderNotFound\",\r\n    \"message\": \"Requested folder not available.\"\r\n  }\r\n}"
+            }
+          },
+          "422": {
+            "description": "Invalid request to update a folder. Make sure that a valid folder ID and folder details were passed in.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"InvalidStorageRequest\",\r\n    \"message\": \"The request to update folder was invalid. Please see the API Reference for possible reasons.\"\r\n  }\r\n}"
+            }
+          },
+          "429": {
+            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
+            "headers": {
+              "retry-after": {
+                "type": "string",
+                "description": "The number of requests exceeds the rate-limit for the client subscription."
+              }
+            },
+            "examples": {
+              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
+            }
+          }
+        }
       }
     },
-    "/files/{fileId}/complete": {
+    "/recycleBin/folders/{folderId}/restore": {
       "post": {
-        "description": "---\r\n\r\nComplete file creation\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:modify*.\r\n\r\n---\r\n",
-        "operationId": "complete-file-creation",
-        "summary": "Complete file creation",
+        "description": "---\r\n\r\nRestore deleted folder from the recycle bin\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n---",
+        "operationId": "restore-folder",
+        "summary": "Restore folder",
+        "tags": ["Folders"],
+        "parameters": [
+          {
+            "name": "folderId",
+            "in": "path",
+            "description": "Folder Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "OAuth access token with scope `storage:modify`",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
+            "type": "string",
+            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
+          }
+        ],
+        "produces": ["application/json"],
+        "responses": {
+          "204": {
+            "description": "A folder was restored successfully."
+          },
+          "401": {
+            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
+            "examples": {
+              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
+            }
+          },
+          "404": {
+            "description": "Folder cannot be found.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FolderNotFound\",\r\n    \"message\": \"Requested folder not available.\"\r\n  }\r\n}"
+            }
+          },
+          "429": {
+            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
+            "headers": {
+              "retry-after": {
+                "type": "string",
+                "description": "The number of requests exceeds the rate-limit for the client subscription."
+              }
+            },
+            "examples": {
+              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
+            }
+          }
+        }
+      }
+    },
+    "/recycleBin/files/{fileId}": {
+      "delete": {
+        "description": "---\r\n\r\nDelete a file from the recycle bin\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n---",
+        "operationId": "delete-file-from-recycle-bin",
+        "summary": "Delete file from recycle bin",
         "tags": ["Files"],
         "parameters": [
           {
@@ -614,28 +506,22 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:modify'",
+            "description": "OAuth access token with scope `storage:modify`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           }
         ],
         "produces": ["application/json"],
         "responses": {
-          "201": {
-            "description": "Created",
-            "schema": {
-              "$ref": "#/definitions/file (created)"
-            },
-            "examples": {
-              "application/json": "{\r\n  \"file\": {\r\n    \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n    \"displayName\": \"test.txt\",\r\n    \"description\": \"test file\",\r\n    \"path\": \"folderName/test.txt\",\r\n    \"size\": 8,\r\n    \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"lastModifiedDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n  }\r\n}\r\n"
-            }
+          "204": {
+            "description": "A file was deleted successfully."
           },
           "401": {
             "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
@@ -664,173 +550,9 @@
         }
       }
     },
-    "/folders/{folderId}/files": {
-      "post": {
-        "description": "---\r\n\r\nCreate new file\r\n\r\n### Notes\r\n\r\nFile creation is three steps operation. This request will create file's meta data. Next two requests need to be executed by using links from the response.\r\n\r\n- uploadUrl is required for file upload. Upload can be done by sending http request and specifying x-ms-blob-type header to BlockBlob.\r\n- completeUrl should be used to confirm file upload and it is final request for file creation.\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:modify*.\r\n\r\n### Errors\r\n\r\nThis request can return InvalidCreateFileRequest error with 422 status code. This could happen because of these reasons:\r\n\r\n- File name contains invalid characters.\r\n- File name's length is larger than 255 characters.\r\n- File could be harmful. For example, executable files are not accepted.\r\n\r\n---\r\n",
-        "operationId": "create-file",
-        "summary": "Create file",
-        "tags": ["Files"],
-        "parameters": [
-          {
-            "name": "folderId",
-            "in": "path",
-            "description": "Folder Id",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "OAuth access token with scope 'storage:modify'",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Accept",
-            "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
-            "type": "string",
-            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
-          },
-          {
-            "name": "file (create)",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/file (create)"
-            }
-          }
-        ],
-        "consumes": ["application/json"],
-        "produces": ["application/json"],
-        "responses": {
-          "202": {
-            "description": "Accepted",
-            "schema": {
-              "$ref": "#/definitions/file (upload)"
-            },
-            "examples": {
-              "application/json": "{\r\n  \"_links\":{\r\n    \"completeUrl\": {\r\n        \"href\": \"https://api.bentley.com/storage/files/TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI/complete\"\r\n    },\r\n    \"uploadUrl\": {\r\n      \"href\": \"https://projectshareprodeussa01.blob.core.windows.net/azuresqldbecpluginstorage/ProjectShare/File/b6145b7f-fee9-4a13-b1e4-5d061970373e?sv=2017-04-17&sr=b&sig=4NfdEriAONQhbHGkrTAL4bNMzjW8Qm5l%2FoEPiSQl%2BPo%3D&se=2020-10-19T15:12:51Z&sp=rw&rscd=attachment%3B%20filename%3D%22test.txt%22&userid=b905387c-a685-4d27-aab7-468c9ff0c9a6\"\r\n    }\r\n  }\r\n}\r\n\r\n"
-            }
-          },
-          "401": {
-            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
-            "examples": {
-              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
-            }
-          },
-          "404": {
-            "description": "Parent folder cannot be found.",
-            "examples": {
-              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FolderNotFound\",\r\n    \"message\": \"Requested folder not available.\"\r\n  }\r\n}"
-            }
-          },
-          "422": {
-            "description": "Invalid request to create a file. Make sure that a valid file ID and file details were passed in.",
-            "examples": {
-              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"InvalidStorageRequest\",\r\n    \"message\": \"The request to create file was invalid. Please see the API Reference for possible reasons.\"\r\n  }\r\n}"
-            }
-          },
-          "429": {
-            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
-            "headers": {
-              "retry-after": {
-                "type": "string",
-                "description": "The number of requests exceeds the rate-limit for the client subscription."
-              }
-            },
-            "examples": {
-              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
-            }
-          }
-        }
-      },
-      "get": {
-        "description": "---\r\n\r\nRetrieves files\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:read*.\r\n\r\n---",
-        "operationId": "get-files-in-folder",
-        "summary": "Get files in folder",
-        "tags": ["Files"],
-        "parameters": [
-          {
-            "name": "folderId",
-            "in": "path",
-            "description": "Folder Id",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "$top",
-            "in": "query",
-            "description": "The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.",
-            "type": "integer"
-          },
-          {
-            "name": "$skip",
-            "in": "query",
-            "description": "The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.",
-            "type": "integer"
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "OAuth access token with scope 'storage:read'",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Accept",
-            "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
-            "type": "string",
-            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
-          }
-        ],
-        "produces": ["application/json"],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/files"
-            },
-            "examples": {
-              "application/json": "{\r\n  \"files\": [\r\n    {\r\n      \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n      \"displayName\": \"test.txt\",\r\n      \"description\": \"test file\",\r\n      \"path\": \"folderName/test.txt\",\r\n      \"size\": 1,\r\n      \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n      \"lastModifiedDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n      \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n    },\r\n    {\r\n      \"id\": \"TYJsPN0xtkWId0yUrXkS5s4FlCroosBMlyDhZZmlzoc\",\r\n      \"displayName\": \"test2.txt\",\r\n      \"description\": \"test file 2\",\r\n      \"path\": \"folderName/test2.txt\",\r\n      \"size\": 1,\r\n      \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"createdDateTime\": \"2020-05-03T11:05:12.0133549Z\",\r\n      \"lastModifiedDateTime\": \"2020-05-03T11:05:12.0133549Z\",\r\n      \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n    }\r\n  ],\r\n  \"_links\": {\r\n    \"self\": {\r\n      \"href\": \"https://api.bentley.com/storage/folders/TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s/files?$skip=4&$top=2\"\r\n    },\r\n    \"prev\": {\r\n      \"href\": \"https://api.bentley.com/storage/folders/TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s/files?$skip=2&$top=2\"\r\n    },\r\n    \"next\": {\r\n      \"href\": \"https://api.bentley.com/storage/folders/TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s/files?$skip=6&$top=2\"\r\n    }\r\n  }\r\n}\r\n"
-            }
-          },
-          "401": {
-            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
-            "examples": {
-              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
-            }
-          },
-          "404": {
-            "description": "Folder cannot be found.",
-            "examples": {
-              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FolderNotFound\",\r\n    \"message\": \"Requested folder not available.\"\r\n  }\r\n}"
-            }
-          },
-          "422": {
-            "description": "Invalid request to get files in folder",
-            "examples": {
-              "application/json": "{\r\n    \"error\": {\r\n        \"code\": \"InvalidStorageRequest\",\r\n        \"message\": \"Page size is over 1000 items limit.\"\r\n    }\r\n}"
-            }
-          },
-          "429": {
-            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
-            "headers": {
-              "retry-after": {
-                "type": "string",
-                "description": "The number of requests exceeds the rate-limit for the client subscription."
-              }
-            },
-            "examples": {
-              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
-            }
-          }
-        }
-      }
-    },
     "/folders/{folderId}/folders": {
       "post": {
-        "description": "---\r\n\r\nCreate new folder\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:modify*.\r\n\r\n### Errors\r\n\r\nThis request can return InvalidCreateFolderRequest error with 422 status code. This could happen because of these reasons:\r\n\r\n- Folder name contains invalid characters.\r\n- Folder name's length is larger than 255 characters.\r\n\r\n---\r\n",
+        "description": "---\r\n\r\nCreate new folder\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n### Errors\r\n\r\nThis request can return InvalidCreateFolderRequest error with 422 status code. This could happen because of these reasons:\r\n\r\n- Folder name contains invalid characters.\r\n- Folder name's length is larger than 255 characters.\r\n\r\n---\r\n",
         "operationId": "create-folder",
         "summary": "Create folder",
         "tags": ["Folders"],
@@ -845,22 +567,22 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:modify'",
+            "description": "OAuth access token with scope `storage:modify`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           },
           {
-            "name": "folder (create)",
+            "name": "folder-create",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/folder (create)"
+              "$ref": "#/definitions/folder-create"
             }
           }
         ],
@@ -870,7 +592,7 @@
           "201": {
             "description": "Created",
             "schema": {
-              "$ref": "#/definitions/folder (created)"
+              "$ref": "#/definitions/folder-result"
             },
             "examples": {
               "application/json": "{\r\n  \"folder\": {\r\n    \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n    \"displayName\": \"test\",\r\n    \"description\": \"test folder\",\r\n    \"path\": \"folderName/test\",\r\n    \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"lastModifiedDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n  }\r\n}\r\n"
@@ -909,7 +631,7 @@
         }
       },
       "get": {
-        "description": "---\r\n\r\nRetrieves folders\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:read*.\r\n\r\n---",
+        "description": "---\r\n\r\nRetrieves folders\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:read`.\r\n\r\n---",
         "operationId": "get-folders-in-folder",
         "summary": "Get folders in folder",
         "tags": ["Folders"],
@@ -936,14 +658,14 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:read'",
+            "description": "OAuth access token with scope `storage:read`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           }
@@ -992,9 +714,214 @@
         }
       }
     },
+    "/files/{fileId}": {
+      "get": {
+        "description": "---\r\n\r\nRetrieves file\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:read`.\r\n\r\n---",
+        "operationId": "get-file",
+        "summary": "Get file",
+        "tags": ["Files"],
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "File Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "OAuth access token with scope `storage:read`",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
+            "type": "string",
+            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
+          }
+        ],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/file-result"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"file\": {\r\n    \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n    \"displayName\": \"file.txt\",\r\n    \"description\": \"test file\",\r\n    \"path\": \"folderName/file.txt\",\r\n    \"size\": 1,\r\n    \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"lastModifiedDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n  }\r\n}\r\n"
+            }
+          },
+          "401": {
+            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
+            "examples": {
+              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
+            }
+          },
+          "404": {
+            "description": "File cannot be found.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FileNotFound\",\r\n    \"message\": \"Requested file not available.\"\r\n  }\r\n}"
+            }
+          },
+          "429": {
+            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
+            "headers": {
+              "retry-after": {
+                "type": "string",
+                "description": "The number of requests exceeds the rate-limit for the client subscription."
+              }
+            },
+            "examples": {
+              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "---\r\n\r\nUpdate file\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n### Errors\r\n\r\nThis request can return InvalidCreateFileRequest error with 422 status code. This could happen because of these reasons:\r\n\r\n- File name contains invalid characters.\r\n- File name's length is larger than 255 characters.\r\n- File could be harmful. For example, executable files are not accepted.\r\n\r\n---\r\n",
+        "operationId": "update-file",
+        "summary": "Update file",
+        "tags": ["Files"],
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "File Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "OAuth access token with scope `storage:modify`",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
+            "type": "string",
+            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
+          },
+          {
+            "name": "file-update",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/file-update"
+            }
+          }
+        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/file-result"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"file\": {\r\n    \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n    \"displayName\": \"test.txt\",\r\n    \"description\": \"test file\",\r\n    \"path\": \"folderName/test.txt\",\r\n    \"size\": 8,\r\n    \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"lastModifiedDateTime\": \"2021-05-15T12:07:06.7841448Z\",\r\n    \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n  }\r\n}\r\n"
+            }
+          },
+          "401": {
+            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
+            "examples": {
+              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
+            }
+          },
+          "404": {
+            "description": "File cannot be found.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FileNotFound\",\r\n    \"message\": \"Requested file not available.\"\r\n  }\r\n}"
+            }
+          },
+          "422": {
+            "description": "Invalid request to update a file. Make sure that a valid file ID and file details were passed in.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"InvalidStorageRequest\",\r\n    \"message\": \"The request to update file was invalid. Please see the API Reference for possible reasons.\"\r\n  }\r\n}"
+            }
+          },
+          "429": {
+            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
+            "headers": {
+              "retry-after": {
+                "type": "string",
+                "description": "The number of requests exceeds the rate-limit for the client subscription."
+              }
+            },
+            "examples": {
+              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "---\r\n\r\nDelete a file\r\n\r\n### Notes\r\n\r\nFile moved to the recycle bin will be completely removed after 30 days.\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n---",
+        "operationId": "delete-file",
+        "summary": "Delete file",
+        "tags": ["Files"],
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "File Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "OAuth access token with scope `storage:modify`",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
+            "type": "string",
+            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
+          }
+        ],
+        "produces": ["application/json"],
+        "responses": {
+          "204": {
+            "description": "A file was deleted successfully."
+          },
+          "401": {
+            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
+            "examples": {
+              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
+            }
+          },
+          "404": {
+            "description": "File cannot be found.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FileNotFound\",\r\n    \"message\": \"Requested file not available.\"\r\n  }\r\n}"
+            }
+          },
+          "429": {
+            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
+            "headers": {
+              "retry-after": {
+                "type": "string",
+                "description": "The number of requests exceeds the rate-limit for the client subscription."
+              }
+            },
+            "examples": {
+              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
+            }
+          }
+        }
+      }
+    },
     "/folders/{folderId}/search": {
       "get": {
-        "description": "---\r\n\r\nFinds files and folders in folder by name\r\n\r\n### Notes\r\n\r\nThis query supports wildcard characters in the name parameter\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:read*.\r\n\r\n---",
+        "description": "---\r\n\r\nFinds files and folders in folder by name\r\n\r\n### Notes\r\n\r\nThis query supports wildcard characters in the name parameter\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:read`.\r\n\r\n---",
         "operationId": "search-for-folders-and-files-in-folder",
         "summary": "Search for folders and files in folder",
         "tags": ["Folders", "Files"],
@@ -1028,14 +955,14 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:read'",
+            "description": "OAuth access token with scope `storage:read`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           }
@@ -1064,7 +991,7 @@
             }
           },
           "422": {
-            "description": "Invalid request to get projects",
+            "description": "Invalid request to search for folders and files",
             "examples": {
               "application/json": "{\r\n    \"error\": {\r\n        \"code\": \"InvalidStorageRequest\",\r\n        \"message\": \"Page size is over 1000 items limit.\"\r\n    }\r\n}"
             }
@@ -1086,7 +1013,7 @@
     },
     "/folders/{folderId}/list": {
       "get": {
-        "description": "---\r\n\r\nRetrieves files and folders\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:read*.\r\n\r\n---",
+        "description": "---\r\n\r\nRetrieves files and folders\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:read`.\r\n\r\n---",
         "operationId": "get-folders-and-files-in-folder",
         "summary": "Get folders and files in folder",
         "tags": ["Folders", "Files"],
@@ -1113,14 +1040,14 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:read'",
+            "description": "OAuth access token with scope `storage:read`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           }
@@ -1169,9 +1096,319 @@
         }
       }
     },
+    "/files/{fileId}/complete": {
+      "post": {
+        "description": "---\r\n\r\nComplete file creation\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n---\r\n",
+        "operationId": "complete-file-creation",
+        "summary": "Complete file creation",
+        "tags": ["Files"],
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "File Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "OAuth access token with scope `storage:modify`",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
+            "type": "string",
+            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
+          }
+        ],
+        "produces": ["application/json"],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/file-result"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"file\": {\r\n    \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n    \"displayName\": \"test.txt\",\r\n    \"description\": \"test file\",\r\n    \"path\": \"folderName/test.txt\",\r\n    \"size\": 8,\r\n    \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"lastModifiedDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n  }\r\n}\r\n"
+            }
+          },
+          "401": {
+            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
+            "examples": {
+              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
+            }
+          },
+          "404": {
+            "description": "File cannot be found.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FileNotFound\",\r\n    \"message\": \"Requested file not available.\"\r\n  }\r\n}"
+            }
+          },
+          "429": {
+            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
+            "headers": {
+              "retry-after": {
+                "type": "string",
+                "description": "The number of requests exceeds the rate-limit for the client subscription."
+              }
+            },
+            "examples": {
+              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
+            }
+          }
+        }
+      }
+    },
+    "/folders/{folderId}/files": {
+      "get": {
+        "description": "---\r\n\r\nRetrieves files\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:read`.\r\n\r\n---",
+        "operationId": "get-files-in-folder",
+        "summary": "Get files in folder",
+        "tags": ["Files"],
+        "parameters": [
+          {
+            "name": "folderId",
+            "in": "path",
+            "description": "Folder Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.",
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.",
+            "type": "integer"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "OAuth access token with scope `storage:read`",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
+            "type": "string",
+            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
+          }
+        ],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/files"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"files\": [\r\n    {\r\n      \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n      \"displayName\": \"test.txt\",\r\n      \"description\": \"test file\",\r\n      \"path\": \"folderName/test.txt\",\r\n      \"size\": 1,\r\n      \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n      \"lastModifiedDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n      \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n    },\r\n    {\r\n      \"id\": \"TYJsPN0xtkWId0yUrXkS5s4FlCroosBMlyDhZZmlzoc\",\r\n      \"displayName\": \"test2.txt\",\r\n      \"description\": \"test file 2\",\r\n      \"path\": \"folderName/test2.txt\",\r\n      \"size\": 1,\r\n      \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"createdDateTime\": \"2020-05-03T11:05:12.0133549Z\",\r\n      \"lastModifiedDateTime\": \"2020-05-03T11:05:12.0133549Z\",\r\n      \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n    }\r\n  ],\r\n  \"_links\": {\r\n    \"self\": {\r\n      \"href\": \"https://api.bentley.com/storage/folders/TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s/files?$skip=4&$top=2\"\r\n    },\r\n    \"prev\": {\r\n      \"href\": \"https://api.bentley.com/storage/folders/TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s/files?$skip=2&$top=2\"\r\n    },\r\n    \"next\": {\r\n      \"href\": \"https://api.bentley.com/storage/folders/TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s/files?$skip=6&$top=2\"\r\n    }\r\n  }\r\n}\r\n"
+            }
+          },
+          "401": {
+            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
+            "examples": {
+              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
+            }
+          },
+          "404": {
+            "description": "Folder cannot be found.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FolderNotFound\",\r\n    \"message\": \"Requested folder not available.\"\r\n  }\r\n}"
+            }
+          },
+          "422": {
+            "description": "Invalid request to get files in folder",
+            "examples": {
+              "application/json": "{\r\n    \"error\": {\r\n        \"code\": \"InvalidStorageRequest\",\r\n        \"message\": \"Page size is over 1000 items limit.\"\r\n    }\r\n}"
+            }
+          },
+          "429": {
+            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
+            "headers": {
+              "retry-after": {
+                "type": "string",
+                "description": "The number of requests exceeds the rate-limit for the client subscription."
+              }
+            },
+            "examples": {
+              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "---\r\n\r\nCreate new file\r\n\r\n### Notes\r\n\r\nFile creation is three steps operation. This request will create file's meta data. Next two requests need to be executed by using links from the response.\r\n\r\n- uploadUrl is required for file upload. Upload can be done by sending http request and specifying x-ms-blob-type header to BlockBlob.\r\n- completeUrl should be used to confirm file upload and it is final request for file creation.\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n### Errors\r\n\r\nThis request can return InvalidCreateFileRequest error with 422 status code. This could happen because of these reasons:\r\n\r\n- File name contains invalid characters.\r\n- File name's length is larger than 255 characters.\r\n- File could be harmful. For example, executable files are not accepted.\r\n\r\n---\r\n",
+        "operationId": "create-file",
+        "summary": "Create file",
+        "tags": ["Files"],
+        "parameters": [
+          {
+            "name": "folderId",
+            "in": "path",
+            "description": "Folder Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "OAuth access token with scope `storage:modify`",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
+            "type": "string",
+            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
+          },
+          {
+            "name": "file-create",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/file-create"
+            }
+          }
+        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "responses": {
+          "202": {
+            "description": "Accepted",
+            "schema": {
+              "$ref": "#/definitions/file-upload"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"_links\":{\r\n    \"completeUrl\": {\r\n        \"href\": \"https://api.bentley.com/storage/files/TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI/complete\"\r\n    },\r\n    \"uploadUrl\": {\r\n      \"href\": \"https://projectshareprodeussa01.blob.core.windows.net/azuresqldbecpluginstorage/ProjectShare/File/b6145b7f-fee9-4a13-b1e4-5d061970373e?sv=2017-04-17&sr=b&sig=4NfdEriAONQhbHGkrTAL4bNMzjW8Qm5l%2FoEPiSQl%2BPo%3D&se=2020-10-19T15:12:51Z&sp=rw&rscd=attachment%3B%20filename%3D%22test.txt%22&userid=b905387c-a685-4d27-aab7-468c9ff0c9a6\"\r\n    }\r\n  }\r\n}\r\n\r\n"
+            }
+          },
+          "401": {
+            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
+            "examples": {
+              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
+            }
+          },
+          "404": {
+            "description": "Parent folder cannot be found.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FolderNotFound\",\r\n    \"message\": \"Requested folder not available.\"\r\n  }\r\n}"
+            }
+          },
+          "422": {
+            "description": "Invalid request to create a file. Make sure that a valid file ID and file details were passed in.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"InvalidStorageRequest\",\r\n    \"message\": \"The request to create file was invalid. Please see the API Reference for possible reasons.\"\r\n  }\r\n}"
+            }
+          },
+          "429": {
+            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
+            "headers": {
+              "retry-after": {
+                "type": "string",
+                "description": "The number of requests exceeds the rate-limit for the client subscription."
+              }
+            },
+            "examples": {
+              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
+            }
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "description": "---\r\n\r\nRetrieves top level files and folders by project\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:read`.\r\n\r\n---",
+        "operationId": "get-top-level-folders-and-files-by-project",
+        "summary": "Get top level folders and files by project",
+        "tags": ["Folders", "Files"],
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "query",
+            "description": "Project Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.",
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.",
+            "type": "integer"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "OAuth access token with scope `storage:read`",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
+            "type": "string",
+            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
+          }
+        ],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/items"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"items\": [\r\n    {\r\n      \"type\": \"folder\",\r\n      \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n      \"displayName\": \"test\",\r\n      \"description\": \"test folder\",\r\n      \"path\": \"folderName/test\",\r\n      \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n      \"lastModifiedDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n      \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n    },\r\n    {\r\n      \"type\": \"file\",\r\n      \"id\": \"TYJsPN0xtkWId0yUrXkS5s4FlCroosBMlyDhZZmlzoc\",\r\n      \"displayName\": \"test2.txt\",\r\n      \"description\": \"test file 2\",\r\n      \"path\": \"folderName/test2.txt\",\r\n      \"size\": 1,\r\n      \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"createdDateTime\": \"2020-05-03T11:05:12.0133549Z\",\r\n      \"lastModifiedDateTime\": \"2020-05-03T11:05:12.0133549Z\",\r\n      \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n    }\r\n  ],\r\n  \"_links\": {\r\n    \"self\": {\r\n      \"href\": \"https://api.bentley.com/storage?projectId=6959daff-27f5-4b87-96ea-9917daa3a8ff&$skip=4&$top=2\"\r\n    },\r\n    \"prev\": {\r\n      \"href\": \"https://api.bentley.com/storage?projectId=6959daff-27f5-4b87-96ea-9917daa3a8ff&$skip=2&$top=2\"\r\n    },\r\n    \"next\": {\r\n      \"href\": \"https://api.bentley.com/storage?projectId=6959daff-27f5-4b87-96ea-9917daa3a8ff&$skip=6&$top=2\"\r\n    },\r\n    \"folder\": {\r\n      \"href\": \"https://api.bentley.com/storage/folders/TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n    }\r\n  }\r\n}\r\n"
+            }
+          },
+          "401": {
+            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
+            "examples": {
+              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
+            }
+          },
+          "422": {
+            "description": "Invalid request to get top level folders and files",
+            "examples": {
+              "application/json": "{\r\n    \"error\": {\r\n        \"code\": \"InvalidStorageRequest\",\r\n        \"message\": \"Page size is over 1000 items limit.\"\r\n    }\r\n}"
+            }
+          },
+          "429": {
+            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
+            "headers": {
+              "retry-after": {
+                "type": "string",
+                "description": "The number of requests exceeds the rate-limit for the client subscription."
+              }
+            },
+            "examples": {
+              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
+            }
+          }
+        }
+      }
+    },
     "/recycleBin": {
       "get": {
-        "description": "---\r\n\r\nGet deleted files and folders\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:read*.\r\n\r\n---",
+        "description": "---\r\n\r\nGet deleted files and folders\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:read`.\r\n\r\n---",
         "operationId": "get-folders-and-files-in-recycle-bin",
         "summary": "Get folders and files in recycle bin",
         "tags": ["Folders", "Files"],
@@ -1198,14 +1435,14 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:read'",
+            "description": "OAuth access token with scope `storage:read`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           }
@@ -1228,7 +1465,7 @@
             }
           },
           "422": {
-            "description": "Invalid request to get projects",
+            "description": "Invalid request to get folders and files in recycle bin",
             "examples": {
               "application/json": "{\r\n    \"error\": {\r\n        \"code\": \"InvalidStorageRequest\",\r\n        \"message\": \"Page size is over 1000 items limit.\"\r\n    }\r\n}"
             }
@@ -1250,16 +1487,28 @@
     }
   },
   "definitions": {
-    "errors": {
+    "minimal-error": {
+      "title": "minimal error",
       "type": "object",
       "properties": {
-        "errors": {
-          "type": "array",
-          "items": {}
+        "self": {
+          "$ref": "#/definitions/error"
         }
       }
     },
-    "links (paging)": {
+    "error": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "code": {
+          "type": "string"
+        }
+      }
+    },
+    "links-paging": {
+      "title": "links (paging)",
       "type": "object",
       "properties": {
         "self": {
@@ -1313,7 +1562,8 @@
         }
       }
     },
-    "folder (typed)": {
+    "folder-typed": {
+      "title": "folder (typed)",
       "type": "object",
       "properties": {
         "id": {
@@ -1348,24 +1598,8 @@
         }
       }
     },
-    "folder (created)": {
-      "type": "object",
-      "properties": {
-        "folder": {
-          "$ref": "#/definitions/folder"
-        }
-      }
-    },
-    "folder (create)": {
-      "type": "object",
-      "properties": {
-        "folder": {
-          "$ref": "#/definitions/folderCreateDetails"
-        }
-      },
-      "example": "{\r\n  \"folder\": {\r\n    \"displayName\": \"test\",\r\n    \"description\": \"test folder\"\r\n  }\r\n}\r\n"
-    },
-    "folderCreateDetails": {
+    "folder-create": {
+      "title": "folder (create)",
       "type": "object",
       "properties": {
         "displayName": {
@@ -1374,7 +1608,31 @@
         "description": {
           "type": "string"
         }
-      }
+      },
+      "example": "{\r\n  \"displayName\": \"test\",\r\n  \"description\": \"test folder\"\r\n}\r\n"
+    },
+    "folder-update": {
+      "title": "folder (update)",
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "example": "{\r\n  \"displayName\": \"test\",\r\n  \"description\": \"test folder\"\r\n}\r\n"
+    },
+    "folder-result": {
+      "title": "folder (result)",
+      "type": "object",
+      "properties": {
+        "folder": {
+          "$ref": "#/definitions/folder-typed"
+        }
+      },
+      "example": "{\r\n  \"displayName\": \"test\",\r\n  \"description\": \"test folder\"\r\n}\r\n"
     },
     "folders": {
       "type": "object",
@@ -1386,7 +1644,16 @@
           }
         },
         "_links": {
-          "$ref": "#/definitions/links (paging)"
+          "$ref": "#/definitions/links-paging"
+        }
+      }
+    },
+    "file-result": {
+      "title": "file (result)",
+      "type": "object",
+      "properties": {
+        "file": {
+          "$ref": "#/definitions/file-typed"
         }
       }
     },
@@ -1425,7 +1692,8 @@
         }
       }
     },
-    "file (typed)": {
+    "file-typed": {
+      "title": "file (typed)",
       "type": "object",
       "properties": {
         "id": {
@@ -1463,24 +1731,8 @@
         }
       }
     },
-    "file (created)": {
-      "type": "object",
-      "properties": {
-        "file": {
-          "$ref": "#/definitions/file"
-        }
-      }
-    },
-    "file (create)": {
-      "type": "object",
-      "properties": {
-        "file": {
-          "$ref": "#/definitions/fileCreateDetails"
-        }
-      },
-      "example": "{\r\n  \"file\": {\r\n    \"displayName\": \"test.txt\",\r\n    \"description\": \"test file\"\r\n  }\r\n}\r\n"
-    },
-    "fileCreateDetails": {
+    "file-create": {
+      "title": "file (create)",
       "type": "object",
       "properties": {
         "displayName": {
@@ -1490,17 +1742,32 @@
           "type": "string"
         }
       },
-      "example": "{\r\n  \"file\": {\r\n    \"displayName\": \"test.txt\",\r\n    \"description\": \"test file\"\r\n  }\r\n}\r\n"
+      "example": "{\r\n  \"displayName\": \"test.txt\",\r\n  \"description\": \"test file\"\r\n}\r\n"
     },
-    "file (upload)": {
+    "file-update": {
+      "title": "file (update)",
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "example": "{\r\n  \"displayName\": \"test.txt\",\r\n  \"description\": \"test file\"\r\n}\r\n"
+    },
+    "file-upload": {
+      "title": "file-upload",
       "type": "object",
       "properties": {
         "_links": {
-          "$ref": "#/definitions/links (upload)"
+          "$ref": "#/definitions/links-upload"
         }
       }
     },
-    "links (upload)": {
+    "links-upload": {
+      "title": "links (upload)",
       "type": "object",
       "properties": {
         "uploadUrl": {
@@ -1521,7 +1788,7 @@
           }
         },
         "_links": {
-          "$ref": "#/definitions/links (paging)"
+          "$ref": "#/definitions/links-paging"
         }
       }
     },
@@ -1533,7 +1800,7 @@
           "items": {}
         },
         "_links": {
-          "$ref": "#/definitions/links (paging)"
+          "$ref": "#/definitions/links-paging"
         }
       }
     }

--- a/packages/app/src/api/storageOpenAPIOriginal.json
+++ b/packages/app/src/api/storageOpenAPIOriginal.json
@@ -6,7 +6,7 @@
     "description": "Storage API allowing quick files managing"
   },
   "host": "api.bentley.com",
-  "basePath": "/storage/v1",
+  "basePath": "/storage",
   "schemes": ["https"],
   "securityDefinitions": {
     "apiKeyHeader": {
@@ -40,131 +40,9 @@
     }
   ],
   "paths": {
-    "/recycleBin/folders/{folderId}/restore": {
-      "post": {
-        "description": "---\r\n\r\nRestore deleted folder from the recycle bin\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:modify*.\r\n\r\n---",
-        "operationId": "restore-folder",
-        "summary": "Restore folder",
-        "tags": ["Folders"],
-        "parameters": [
-          {
-            "name": "folderId",
-            "in": "path",
-            "description": "Folder Id",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "OAuth access token with scope 'storage:modify'",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Accept",
-            "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
-            "type": "string",
-            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
-          }
-        ],
-        "produces": ["application/json"],
-        "responses": {
-          "204": {
-            "description": "A folder was restored successfully."
-          },
-          "401": {
-            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
-            "examples": {
-              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
-            }
-          },
-          "404": {
-            "description": "Folder cannot be found.",
-            "examples": {
-              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FolderNotFound\",\r\n    \"message\": \"Requested folder not available.\"\r\n  }\r\n}"
-            }
-          },
-          "429": {
-            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
-            "headers": {
-              "retry-after": {
-                "type": "string",
-                "description": "The number of requests exceeds the rate-limit for the client subscription."
-              }
-            },
-            "examples": {
-              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
-            }
-          }
-        }
-      }
-    },
-    "/recycleBin/files/{fileId}": {
-      "delete": {
-        "description": "---\r\n\r\nDelete a file from the recycle bin\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:modify*.\r\n\r\n---",
-        "operationId": "delete-file-from-recycle-bin",
-        "summary": "Delete file from recycle bin",
-        "tags": ["Files"],
-        "parameters": [
-          {
-            "name": "fileId",
-            "in": "path",
-            "description": "File Id",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "OAuth access token with scope 'storage:modify'",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Accept",
-            "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
-            "type": "string",
-            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
-          }
-        ],
-        "produces": ["application/json"],
-        "responses": {
-          "204": {
-            "description": "A file was deleted successfully."
-          },
-          "401": {
-            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
-            "examples": {
-              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
-            }
-          },
-          "404": {
-            "description": "File cannot be found.",
-            "examples": {
-              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FileNotFound\",\r\n    \"message\": \"Requested file not available.\"\r\n  }\r\n}"
-            }
-          },
-          "429": {
-            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
-            "headers": {
-              "retry-after": {
-                "type": "string",
-                "description": "The number of requests exceeds the rate-limit for the client subscription."
-              }
-            },
-            "examples": {
-              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
-            }
-          }
-        }
-      }
-    },
     "/files/{fileId}/download": {
       "get": {
-        "description": "---\r\n\r\nRetrieves file\r\n\r\n### Notes\r\n\r\nThis endpoint returns 302 status code with Location header, which on success contains a link to the file. Redirection is not supported by developer portal and an error could be returned while using the \"Try it\" feature for this API. However, this endpoint will work if a request is sent from a different http client or by using the link specified in the response Location header.\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:read*.\r\n\r\n---",
+        "description": "---\r\n\r\nRetrieves file\r\n\r\n### Notes\r\n\r\nThis endpoint returns 302 status code with Location header, which on success contains a link to the file. Redirection is not supported by developer portal and an error could be returned while using the \"Try it\" feature for this API. However, this endpoint will work if a request is sent from a different http client or by using the link specified in the response Location header.\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:read`.\r\n\r\n---",
         "operationId": "download-file",
         "summary": "Download file",
         "tags": ["Files"],
@@ -179,14 +57,14 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:read'",
+            "description": "OAuth access token with scope `storage:read`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           }
@@ -225,7 +103,7 @@
     },
     "/recycleBin/folders/{folderId}": {
       "delete": {
-        "description": "---\r\n\r\nDelete a folder from the recycle bin\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:modify*.\r\n\r\n---",
+        "description": "---\r\n\r\nDelete a folder from the recycle bin\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n---",
         "operationId": "delete-folder-from-recycle-bin",
         "summary": "Delete folder from recycle bin",
         "tags": ["Folders"],
@@ -240,14 +118,14 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:modify'",
+            "description": "OAuth access token with scope `storage:modify`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           }
@@ -286,7 +164,7 @@
     },
     "/recycleBin/files/{fileId}/restore": {
       "post": {
-        "description": "---\r\n\r\nRestore deleted file from the recycle bin\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:modify*.\r\n\r\n---",
+        "description": "---\r\n\r\nRestore deleted file from the recycle bin\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n---",
         "operationId": "restore-file",
         "summary": "Restore file",
         "tags": ["Files"],
@@ -301,14 +179,14 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:modify'",
+            "description": "OAuth access token with scope `storage:modify`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           }
@@ -345,135 +223,9 @@
         }
       }
     },
-    "/files/{fileId}": {
-      "delete": {
-        "description": "---\r\n\r\nDelete a file\r\n\r\n### Notes\r\n\r\nFile moved to the recycle bin will be completely removed after 30 days.\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:modify*.\r\n\r\n---",
-        "operationId": "delete-file",
-        "summary": "Delete file",
-        "tags": ["Files"],
-        "parameters": [
-          {
-            "name": "fileId",
-            "in": "path",
-            "description": "File Id",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "OAuth access token with scope 'storage:modify'",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Accept",
-            "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
-            "type": "string",
-            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
-          }
-        ],
-        "produces": ["application/json"],
-        "responses": {
-          "204": {
-            "description": "A file was deleted successfully."
-          },
-          "401": {
-            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
-            "examples": {
-              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
-            }
-          },
-          "404": {
-            "description": "File cannot be found.",
-            "examples": {
-              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FileNotFound\",\r\n    \"message\": \"Requested file not available.\"\r\n  }\r\n}"
-            }
-          },
-          "429": {
-            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
-            "headers": {
-              "retry-after": {
-                "type": "string",
-                "description": "The number of requests exceeds the rate-limit for the client subscription."
-              }
-            },
-            "examples": {
-              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
-            }
-          }
-        }
-      },
-      "get": {
-        "description": "---\r\n\r\nRetrieves file\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:read*.\r\n\r\n---",
-        "operationId": "get-file",
-        "summary": "Get file",
-        "tags": ["Files"],
-        "parameters": [
-          {
-            "name": "fileId",
-            "in": "path",
-            "description": "File Id",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "OAuth access token with scope 'storage:read'",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Accept",
-            "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
-            "type": "string",
-            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
-          }
-        ],
-        "produces": ["application/json"],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/file"
-            },
-            "examples": {
-              "application/json": "{\r\n  \"file\": {\r\n    \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n    \"displayName\": \"file.txt\",\r\n    \"description\": \"test file\",\r\n    \"path\": \"folderName/file.txt\",\r\n    \"size\": 1,\r\n    \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"lastModifiedDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n  }\r\n}\r\n"
-            }
-          },
-          "401": {
-            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
-            "examples": {
-              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
-            }
-          },
-          "404": {
-            "description": "File cannot be found.",
-            "examples": {
-              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FileNotFound\",\r\n    \"message\": \"Requested file not available.\"\r\n  }\r\n}"
-            }
-          },
-          "429": {
-            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
-            "headers": {
-              "retry-after": {
-                "type": "string",
-                "description": "The number of requests exceeds the rate-limit for the client subscription."
-              }
-            },
-            "examples": {
-              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
-            }
-          }
-        }
-      }
-    },
     "/folders/{folderId}": {
       "delete": {
-        "description": "---\r\n\r\nDelete a folder\r\n\r\n### Notes\r\n\r\nFolder moved to the recycle bin will be completely removed after 30 days.\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:modify*.\r\n\r\n---",
+        "description": "---\r\n\r\nDelete a folder\r\n\r\n### Notes\r\n\r\nFolder moved to the recycle bin will be completely removed after 30 days.\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n---",
         "operationId": "delete-folder",
         "summary": "Delete folder",
         "tags": ["Folders"],
@@ -488,14 +240,14 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:modify'",
+            "description": "OAuth access token with scope `storage:modify`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           }
@@ -532,7 +284,7 @@
         }
       },
       "get": {
-        "description": "---\r\n\r\nRetrieves folder\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:read*.\r\n\r\n---",
+        "description": "---\r\n\r\nRetrieves folder\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:read`.\r\n\r\n---",
         "operationId": "get-folder",
         "summary": "Get folder",
         "tags": ["Folders"],
@@ -547,14 +299,14 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:read'",
+            "description": "OAuth access token with scope `storage:read`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           }
@@ -595,13 +347,153 @@
             }
           }
         }
+      },
+      "patch": {
+        "description": "---\r\n\r\nUpdate folder\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n### Errors\r\n\r\nThis request can return InvalidCreateFolderRequest error with 422 status code. This could happen because of these reasons:\r\n\r\n- Folder name contains invalid characters.\r\n- Folder name's length is larger than 255 characters.\r\n\r\n---\r\n",
+        "operationId": "update-folder",
+        "summary": "Update folder",
+        "tags": ["Folders"],
+        "parameters": [
+          {
+            "name": "folderId",
+            "in": "path",
+            "description": "Folder Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "OAuth access token with scope `storage:modify`",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
+            "type": "string",
+            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
+          },
+          {
+            "name": "folder-update",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/folder-update"
+            }
+          }
+        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/folder"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"folder\": {\r\n    \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n    \"displayName\": \"test\",\r\n    \"description\": \"test folder\",\r\n    \"path\": \"folderName/test\",\r\n    \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"lastModifiedDateTime\": \"2021-05-15T12:07:06.7841448Z\",\r\n    \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n  }\r\n}\r\n"
+            }
+          },
+          "401": {
+            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
+            "examples": {
+              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
+            }
+          },
+          "404": {
+            "description": "Parent folder cannot be found.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FolderNotFound\",\r\n    \"message\": \"Requested folder not available.\"\r\n  }\r\n}"
+            }
+          },
+          "422": {
+            "description": "Invalid request to update a folder. Make sure that a valid folder ID and folder details were passed in.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"InvalidStorageRequest\",\r\n    \"message\": \"The request to update folder was invalid. Please see the API Reference for possible reasons.\"\r\n  }\r\n}"
+            }
+          },
+          "429": {
+            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
+            "headers": {
+              "retry-after": {
+                "type": "string",
+                "description": "The number of requests exceeds the rate-limit for the client subscription."
+              }
+            },
+            "examples": {
+              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
+            }
+          }
+        }
       }
     },
-    "/files/{fileId}/complete": {
+    "/recycleBin/folders/{folderId}/restore": {
       "post": {
-        "description": "---\r\n\r\nComplete file creation\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:modify*.\r\n\r\n---\r\n",
-        "operationId": "complete-file-creation",
-        "summary": "Complete file creation",
+        "description": "---\r\n\r\nRestore deleted folder from the recycle bin\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n---",
+        "operationId": "restore-folder",
+        "summary": "Restore folder",
+        "tags": ["Folders"],
+        "parameters": [
+          {
+            "name": "folderId",
+            "in": "path",
+            "description": "Folder Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "OAuth access token with scope `storage:modify`",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
+            "type": "string",
+            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
+          }
+        ],
+        "produces": ["application/json"],
+        "responses": {
+          "204": {
+            "description": "A folder was restored successfully."
+          },
+          "401": {
+            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
+            "examples": {
+              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
+            }
+          },
+          "404": {
+            "description": "Folder cannot be found.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FolderNotFound\",\r\n    \"message\": \"Requested folder not available.\"\r\n  }\r\n}"
+            }
+          },
+          "429": {
+            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
+            "headers": {
+              "retry-after": {
+                "type": "string",
+                "description": "The number of requests exceeds the rate-limit for the client subscription."
+              }
+            },
+            "examples": {
+              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
+            }
+          }
+        }
+      }
+    },
+    "/recycleBin/files/{fileId}": {
+      "delete": {
+        "description": "---\r\n\r\nDelete a file from the recycle bin\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n---",
+        "operationId": "delete-file-from-recycle-bin",
+        "summary": "Delete file from recycle bin",
         "tags": ["Files"],
         "parameters": [
           {
@@ -614,28 +506,22 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:modify'",
+            "description": "OAuth access token with scope `storage:modify`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           }
         ],
         "produces": ["application/json"],
         "responses": {
-          "201": {
-            "description": "Created",
-            "schema": {
-              "$ref": "#/definitions/file"
-            },
-            "examples": {
-              "application/json": "{\r\n  \"file\": {\r\n    \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n    \"displayName\": \"test.txt\",\r\n    \"description\": \"test file\",\r\n    \"path\": \"folderName/test.txt\",\r\n    \"size\": 8,\r\n    \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"lastModifiedDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n  }\r\n}\r\n"
-            }
+          "204": {
+            "description": "A file was deleted successfully."
           },
           "401": {
             "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
@@ -664,173 +550,9 @@
         }
       }
     },
-    "/folders/{folderId}/files": {
-      "post": {
-        "description": "---\r\n\r\nCreate new file\r\n\r\n### Notes\r\n\r\nFile creation is three steps operation. This request will create file's meta data. Next two requests need to be executed by using links from the response.\r\n\r\n- uploadUrl is required for file upload. Upload can be done by sending http request and specifying x-ms-blob-type header to BlockBlob.\r\n- completeUrl should be used to confirm file upload and it is final request for file creation.\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:modify*.\r\n\r\n### Errors\r\n\r\nThis request can return InvalidCreateFileRequest error with 422 status code. This could happen because of these reasons:\r\n\r\n- File name contains invalid characters.\r\n- File name's length is larger than 255 characters.\r\n- File could be harmful. For example, executable files are not accepted.\r\n\r\n---\r\n",
-        "operationId": "create-file",
-        "summary": "Create file",
-        "tags": ["Files"],
-        "parameters": [
-          {
-            "name": "folderId",
-            "in": "path",
-            "description": "Folder Id",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "OAuth access token with scope 'storage:modify'",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Accept",
-            "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
-            "type": "string",
-            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
-          },
-          {
-            "name": "file (create)",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/file (create)"
-            }
-          }
-        ],
-        "consumes": ["application/json"],
-        "produces": ["application/json"],
-        "responses": {
-          "202": {
-            "description": "Accepted",
-            "schema": {
-              "$ref": "#/definitions/file (upload)"
-            },
-            "examples": {
-              "application/json": "{\r\n  \"_links\":{\r\n    \"completeUrl\": {\r\n        \"href\": \"https://api.bentley.com/storage/files/TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI/complete\"\r\n    },\r\n    \"uploadUrl\": {\r\n      \"href\": \"https://projectshareprodeussa01.blob.core.windows.net/azuresqldbecpluginstorage/ProjectShare/File/b6145b7f-fee9-4a13-b1e4-5d061970373e?sv=2017-04-17&sr=b&sig=4NfdEriAONQhbHGkrTAL4bNMzjW8Qm5l%2FoEPiSQl%2BPo%3D&se=2020-10-19T15:12:51Z&sp=rw&rscd=attachment%3B%20filename%3D%22test.txt%22&userid=b905387c-a685-4d27-aab7-468c9ff0c9a6\"\r\n    }\r\n  }\r\n}\r\n\r\n"
-            }
-          },
-          "401": {
-            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
-            "examples": {
-              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
-            }
-          },
-          "404": {
-            "description": "Parent folder cannot be found.",
-            "examples": {
-              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FolderNotFound\",\r\n    \"message\": \"Requested folder not available.\"\r\n  }\r\n}"
-            }
-          },
-          "422": {
-            "description": "Invalid request to create a file. Make sure that a valid file ID and file details were passed in.",
-            "examples": {
-              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"InvalidStorageRequest\",\r\n    \"message\": \"The request to create file was invalid. Please see the API Reference for possible reasons.\"\r\n  }\r\n}"
-            }
-          },
-          "429": {
-            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
-            "headers": {
-              "retry-after": {
-                "type": "string",
-                "description": "The number of requests exceeds the rate-limit for the client subscription."
-              }
-            },
-            "examples": {
-              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
-            }
-          }
-        }
-      },
-      "get": {
-        "description": "---\r\n\r\nRetrieves files\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:read*.\r\n\r\n---",
-        "operationId": "get-files-in-folder",
-        "summary": "Get files in folder",
-        "tags": ["Files"],
-        "parameters": [
-          {
-            "name": "folderId",
-            "in": "path",
-            "description": "Folder Id",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "$top",
-            "in": "query",
-            "description": "The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.",
-            "type": "integer"
-          },
-          {
-            "name": "$skip",
-            "in": "query",
-            "description": "The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.",
-            "type": "integer"
-          },
-          {
-            "name": "Authorization",
-            "in": "header",
-            "description": "OAuth access token with scope 'storage:read'",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "Accept",
-            "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
-            "type": "string",
-            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
-          }
-        ],
-        "produces": ["application/json"],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/files"
-            },
-            "examples": {
-              "application/json": "{\r\n  \"files\": [\r\n    {\r\n      \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n      \"displayName\": \"test.txt\",\r\n      \"description\": \"test file\",\r\n      \"path\": \"folderName/test.txt\",\r\n      \"size\": 1,\r\n      \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n      \"lastModifiedDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n      \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n    },\r\n    {\r\n      \"id\": \"TYJsPN0xtkWId0yUrXkS5s4FlCroosBMlyDhZZmlzoc\",\r\n      \"displayName\": \"test2.txt\",\r\n      \"description\": \"test file 2\",\r\n      \"path\": \"folderName/test2.txt\",\r\n      \"size\": 1,\r\n      \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"createdDateTime\": \"2020-05-03T11:05:12.0133549Z\",\r\n      \"lastModifiedDateTime\": \"2020-05-03T11:05:12.0133549Z\",\r\n      \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n    }\r\n  ],\r\n  \"_links\": {\r\n    \"self\": {\r\n      \"href\": \"https://api.bentley.com/storage/folders/TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s/files?$skip=4&$top=2\"\r\n    },\r\n    \"prev\": {\r\n      \"href\": \"https://api.bentley.com/storage/folders/TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s/files?$skip=2&$top=2\"\r\n    },\r\n    \"next\": {\r\n      \"href\": \"https://api.bentley.com/storage/folders/TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s/files?$skip=6&$top=2\"\r\n    }\r\n  }\r\n}\r\n"
-            }
-          },
-          "401": {
-            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
-            "examples": {
-              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
-            }
-          },
-          "404": {
-            "description": "Folder cannot be found.",
-            "examples": {
-              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FolderNotFound\",\r\n    \"message\": \"Requested folder not available.\"\r\n  }\r\n}"
-            }
-          },
-          "422": {
-            "description": "Invalid request to get files in folder",
-            "examples": {
-              "application/json": "{\r\n    \"error\": {\r\n        \"code\": \"InvalidStorageRequest\",\r\n        \"message\": \"Page size is over 1000 items limit.\"\r\n    }\r\n}"
-            }
-          },
-          "429": {
-            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
-            "headers": {
-              "retry-after": {
-                "type": "string",
-                "description": "The number of requests exceeds the rate-limit for the client subscription."
-              }
-            },
-            "examples": {
-              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
-            }
-          }
-        }
-      }
-    },
     "/folders/{folderId}/folders": {
       "post": {
-        "description": "---\r\n\r\nCreate new folder\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:modify*.\r\n\r\n### Errors\r\n\r\nThis request can return InvalidCreateFolderRequest error with 422 status code. This could happen because of these reasons:\r\n\r\n- Folder name contains invalid characters.\r\n- Folder name's length is larger than 255 characters.\r\n\r\n---\r\n",
+        "description": "---\r\n\r\nCreate new folder\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n### Errors\r\n\r\nThis request can return InvalidCreateFolderRequest error with 422 status code. This could happen because of these reasons:\r\n\r\n- Folder name contains invalid characters.\r\n- Folder name's length is larger than 255 characters.\r\n\r\n---\r\n",
         "operationId": "create-folder",
         "summary": "Create folder",
         "tags": ["Folders"],
@@ -845,22 +567,22 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:modify'",
+            "description": "OAuth access token with scope `storage:modify`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           },
           {
-            "name": "folder (create)",
+            "name": "folder-create",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/folder (create)"
+              "$ref": "#/definitions/folder-create"
             }
           }
         ],
@@ -870,7 +592,7 @@
           "201": {
             "description": "Created",
             "schema": {
-              "$ref": "#/definitions/folder (create)"
+              "$ref": "#/definitions/folder"
             },
             "examples": {
               "application/json": "{\r\n  \"folder\": {\r\n    \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n    \"displayName\": \"test\",\r\n    \"description\": \"test folder\",\r\n    \"path\": \"folderName/test\",\r\n    \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"lastModifiedDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n  }\r\n}\r\n"
@@ -909,7 +631,7 @@
         }
       },
       "get": {
-        "description": "---\r\n\r\nRetrieves folders\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:read*.\r\n\r\n---",
+        "description": "---\r\n\r\nRetrieves folders\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:read`.\r\n\r\n---",
         "operationId": "get-folders-in-folder",
         "summary": "Get folders in folder",
         "tags": ["Folders"],
@@ -936,14 +658,14 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:read'",
+            "description": "OAuth access token with scope `storage:read`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           }
@@ -992,9 +714,214 @@
         }
       }
     },
+    "/files/{fileId}": {
+      "get": {
+        "description": "---\r\n\r\nRetrieves file\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:read`.\r\n\r\n---",
+        "operationId": "get-file",
+        "summary": "Get file",
+        "tags": ["Files"],
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "File Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "OAuth access token with scope `storage:read`",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
+            "type": "string",
+            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
+          }
+        ],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/file"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"file\": {\r\n    \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n    \"displayName\": \"file.txt\",\r\n    \"description\": \"test file\",\r\n    \"path\": \"folderName/file.txt\",\r\n    \"size\": 1,\r\n    \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"lastModifiedDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n  }\r\n}\r\n"
+            }
+          },
+          "401": {
+            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
+            "examples": {
+              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
+            }
+          },
+          "404": {
+            "description": "File cannot be found.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FileNotFound\",\r\n    \"message\": \"Requested file not available.\"\r\n  }\r\n}"
+            }
+          },
+          "429": {
+            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
+            "headers": {
+              "retry-after": {
+                "type": "string",
+                "description": "The number of requests exceeds the rate-limit for the client subscription."
+              }
+            },
+            "examples": {
+              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "---\r\n\r\nUpdate file\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n### Errors\r\n\r\nThis request can return InvalidCreateFileRequest error with 422 status code. This could happen because of these reasons:\r\n\r\n- File name contains invalid characters.\r\n- File name's length is larger than 255 characters.\r\n- File could be harmful. For example, executable files are not accepted.\r\n\r\n---\r\n",
+        "operationId": "update-file",
+        "summary": "Update file",
+        "tags": ["Files"],
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "File Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "OAuth access token with scope `storage:modify`",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
+            "type": "string",
+            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
+          },
+          {
+            "name": "file-update",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/file-update"
+            }
+          }
+        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/file"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"file\": {\r\n    \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n    \"displayName\": \"test.txt\",\r\n    \"description\": \"test file\",\r\n    \"path\": \"folderName/test.txt\",\r\n    \"size\": 8,\r\n    \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"lastModifiedDateTime\": \"2021-05-15T12:07:06.7841448Z\",\r\n    \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n  }\r\n}\r\n"
+            }
+          },
+          "401": {
+            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
+            "examples": {
+              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
+            }
+          },
+          "404": {
+            "description": "File cannot be found.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FileNotFound\",\r\n    \"message\": \"Requested file not available.\"\r\n  }\r\n}"
+            }
+          },
+          "422": {
+            "description": "Invalid request to update a file. Make sure that a valid file ID and file details were passed in.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"InvalidStorageRequest\",\r\n    \"message\": \"The request to update file was invalid. Please see the API Reference for possible reasons.\"\r\n  }\r\n}"
+            }
+          },
+          "429": {
+            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
+            "headers": {
+              "retry-after": {
+                "type": "string",
+                "description": "The number of requests exceeds the rate-limit for the client subscription."
+              }
+            },
+            "examples": {
+              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "---\r\n\r\nDelete a file\r\n\r\n### Notes\r\n\r\nFile moved to the recycle bin will be completely removed after 30 days.\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n---",
+        "operationId": "delete-file",
+        "summary": "Delete file",
+        "tags": ["Files"],
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "File Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "OAuth access token with scope `storage:modify`",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
+            "type": "string",
+            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
+          }
+        ],
+        "produces": ["application/json"],
+        "responses": {
+          "204": {
+            "description": "A file was deleted successfully."
+          },
+          "401": {
+            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
+            "examples": {
+              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
+            }
+          },
+          "404": {
+            "description": "File cannot be found.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FileNotFound\",\r\n    \"message\": \"Requested file not available.\"\r\n  }\r\n}"
+            }
+          },
+          "429": {
+            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
+            "headers": {
+              "retry-after": {
+                "type": "string",
+                "description": "The number of requests exceeds the rate-limit for the client subscription."
+              }
+            },
+            "examples": {
+              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
+            }
+          }
+        }
+      }
+    },
     "/folders/{folderId}/search": {
       "get": {
-        "description": "---\r\n\r\nFinds files and folders in folder by name\r\n\r\n### Notes\r\n\r\nThis query supports wildcard characters in the name parameter\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:read*.\r\n\r\n---",
+        "description": "---\r\n\r\nFinds files and folders in folder by name\r\n\r\n### Notes\r\n\r\nThis query supports wildcard characters in the name parameter\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:read`.\r\n\r\n---",
         "operationId": "search-for-folders-and-files-in-folder",
         "summary": "Search for folders and files in folder",
         "tags": ["Folders", "Files"],
@@ -1028,14 +955,14 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:read'",
+            "description": "OAuth access token with scope `storage:read`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           }
@@ -1064,7 +991,7 @@
             }
           },
           "422": {
-            "description": "Invalid request to get projects",
+            "description": "Invalid request to search for folders and files",
             "examples": {
               "application/json": "{\r\n    \"error\": {\r\n        \"code\": \"InvalidStorageRequest\",\r\n        \"message\": \"Page size is over 1000 items limit.\"\r\n    }\r\n}"
             }
@@ -1086,7 +1013,7 @@
     },
     "/folders/{folderId}/list": {
       "get": {
-        "description": "---\r\n\r\nRetrieves files and folders\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:read*.\r\n\r\n---",
+        "description": "---\r\n\r\nRetrieves files and folders\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:read`.\r\n\r\n---",
         "operationId": "get-folders-and-files-in-folder",
         "summary": "Get folders and files in folder",
         "tags": ["Folders", "Files"],
@@ -1113,14 +1040,14 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:read'",
+            "description": "OAuth access token with scope `storage:read`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           }
@@ -1169,9 +1096,319 @@
         }
       }
     },
+    "/files/{fileId}/complete": {
+      "post": {
+        "description": "---\r\n\r\nComplete file creation\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n---\r\n",
+        "operationId": "complete-file-creation",
+        "summary": "Complete file creation",
+        "tags": ["Files"],
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "File Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "OAuth access token with scope `storage:modify`",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
+            "type": "string",
+            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
+          }
+        ],
+        "produces": ["application/json"],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/file"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"file\": {\r\n    \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n    \"displayName\": \"test.txt\",\r\n    \"description\": \"test file\",\r\n    \"path\": \"folderName/test.txt\",\r\n    \"size\": 8,\r\n    \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n    \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"lastModifiedDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n    \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n  }\r\n}\r\n"
+            }
+          },
+          "401": {
+            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
+            "examples": {
+              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
+            }
+          },
+          "404": {
+            "description": "File cannot be found.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FileNotFound\",\r\n    \"message\": \"Requested file not available.\"\r\n  }\r\n}"
+            }
+          },
+          "429": {
+            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
+            "headers": {
+              "retry-after": {
+                "type": "string",
+                "description": "The number of requests exceeds the rate-limit for the client subscription."
+              }
+            },
+            "examples": {
+              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
+            }
+          }
+        }
+      }
+    },
+    "/folders/{folderId}/files": {
+      "get": {
+        "description": "---\r\n\r\nRetrieves files\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:read`.\r\n\r\n---",
+        "operationId": "get-files-in-folder",
+        "summary": "Get files in folder",
+        "tags": ["Files"],
+        "parameters": [
+          {
+            "name": "folderId",
+            "in": "path",
+            "description": "Folder Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.",
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.",
+            "type": "integer"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "OAuth access token with scope `storage:read`",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
+            "type": "string",
+            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
+          }
+        ],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/files"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"files\": [\r\n    {\r\n      \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n      \"displayName\": \"test.txt\",\r\n      \"description\": \"test file\",\r\n      \"path\": \"folderName/test.txt\",\r\n      \"size\": 1,\r\n      \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n      \"lastModifiedDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n      \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n    },\r\n    {\r\n      \"id\": \"TYJsPN0xtkWId0yUrXkS5s4FlCroosBMlyDhZZmlzoc\",\r\n      \"displayName\": \"test2.txt\",\r\n      \"description\": \"test file 2\",\r\n      \"path\": \"folderName/test2.txt\",\r\n      \"size\": 1,\r\n      \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"createdDateTime\": \"2020-05-03T11:05:12.0133549Z\",\r\n      \"lastModifiedDateTime\": \"2020-05-03T11:05:12.0133549Z\",\r\n      \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n    }\r\n  ],\r\n  \"_links\": {\r\n    \"self\": {\r\n      \"href\": \"https://api.bentley.com/storage/folders/TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s/files?$skip=4&$top=2\"\r\n    },\r\n    \"prev\": {\r\n      \"href\": \"https://api.bentley.com/storage/folders/TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s/files?$skip=2&$top=2\"\r\n    },\r\n    \"next\": {\r\n      \"href\": \"https://api.bentley.com/storage/folders/TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s/files?$skip=6&$top=2\"\r\n    }\r\n  }\r\n}\r\n"
+            }
+          },
+          "401": {
+            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
+            "examples": {
+              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
+            }
+          },
+          "404": {
+            "description": "Folder cannot be found.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FolderNotFound\",\r\n    \"message\": \"Requested folder not available.\"\r\n  }\r\n}"
+            }
+          },
+          "422": {
+            "description": "Invalid request to get files in folder",
+            "examples": {
+              "application/json": "{\r\n    \"error\": {\r\n        \"code\": \"InvalidStorageRequest\",\r\n        \"message\": \"Page size is over 1000 items limit.\"\r\n    }\r\n}"
+            }
+          },
+          "429": {
+            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
+            "headers": {
+              "retry-after": {
+                "type": "string",
+                "description": "The number of requests exceeds the rate-limit for the client subscription."
+              }
+            },
+            "examples": {
+              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "---\r\n\r\nCreate new file\r\n\r\n### Notes\r\n\r\nFile creation is three steps operation. This request will create file's meta data. Next two requests need to be executed by using links from the response.\r\n\r\n- uploadUrl is required for file upload. Upload can be done by sending http request and specifying x-ms-blob-type header to BlockBlob.\r\n- completeUrl should be used to confirm file upload and it is final request for file creation.\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:modify`.\r\n\r\n### Errors\r\n\r\nThis request can return InvalidCreateFileRequest error with 422 status code. This could happen because of these reasons:\r\n\r\n- File name contains invalid characters.\r\n- File name's length is larger than 255 characters.\r\n- File could be harmful. For example, executable files are not accepted.\r\n\r\n---\r\n",
+        "operationId": "create-file",
+        "summary": "Create file",
+        "tags": ["Files"],
+        "parameters": [
+          {
+            "name": "folderId",
+            "in": "path",
+            "description": "Folder Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "OAuth access token with scope `storage:modify`",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
+            "type": "string",
+            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
+          },
+          {
+            "name": "file-create",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/file-create"
+            }
+          }
+        ],
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "responses": {
+          "202": {
+            "description": "Accepted",
+            "schema": {
+              "$ref": "#/definitions/file-upload"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"_links\":{\r\n    \"completeUrl\": {\r\n        \"href\": \"https://api.bentley.com/storage/files/TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI/complete\"\r\n    },\r\n    \"uploadUrl\": {\r\n      \"href\": \"https://projectshareprodeussa01.blob.core.windows.net/azuresqldbecpluginstorage/ProjectShare/File/b6145b7f-fee9-4a13-b1e4-5d061970373e?sv=2017-04-17&sr=b&sig=4NfdEriAONQhbHGkrTAL4bNMzjW8Qm5l%2FoEPiSQl%2BPo%3D&se=2020-10-19T15:12:51Z&sp=rw&rscd=attachment%3B%20filename%3D%22test.txt%22&userid=b905387c-a685-4d27-aab7-468c9ff0c9a6\"\r\n    }\r\n  }\r\n}\r\n\r\n"
+            }
+          },
+          "401": {
+            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
+            "examples": {
+              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
+            }
+          },
+          "404": {
+            "description": "Parent folder cannot be found.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"FolderNotFound\",\r\n    \"message\": \"Requested folder not available.\"\r\n  }\r\n}"
+            }
+          },
+          "422": {
+            "description": "Invalid request to create a file. Make sure that a valid file ID and file details were passed in.",
+            "examples": {
+              "application/json": "{\r\n  \"error\": {\r\n    \"code\": \"InvalidStorageRequest\",\r\n    \"message\": \"The request to create file was invalid. Please see the API Reference for possible reasons.\"\r\n  }\r\n}"
+            }
+          },
+          "429": {
+            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
+            "headers": {
+              "retry-after": {
+                "type": "string",
+                "description": "The number of requests exceeds the rate-limit for the client subscription."
+              }
+            },
+            "examples": {
+              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
+            }
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "description": "---\r\n\r\nRetrieves top level files and folders by project\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:read`.\r\n\r\n---",
+        "operationId": "get-top-level-folders-and-files-by-project",
+        "summary": "Get top level folders and files by project",
+        "tags": ["Folders", "Files"],
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "query",
+            "description": "Project Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The [$top](https://www.odata.org/getting-started/basic-tutorial/#topskip) system query option requests the number of items in the queried collection to be included in the result.",
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "The [$skip](https://www.odata.org/getting-started/basic-tutorial/#topskip) query option requests the number of items in the queried collection that are to be skipped and not included in the result.",
+            "type": "integer"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "OAuth access token with scope `storage:read`",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Accept",
+            "in": "header",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
+            "type": "string",
+            "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
+          }
+        ],
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/items"
+            },
+            "examples": {
+              "application/json": "{\r\n  \"items\": [\r\n    {\r\n      \"type\": \"folder\",\r\n      \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n      \"displayName\": \"test\",\r\n      \"description\": \"test folder\",\r\n      \"path\": \"folderName/test\",\r\n      \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n      \"lastModifiedDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n      \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n    },\r\n    {\r\n      \"type\": \"file\",\r\n      \"id\": \"TYJsPN0xtkWId0yUrXkS5s4FlCroosBMlyDhZZmlzoc\",\r\n      \"displayName\": \"test2.txt\",\r\n      \"description\": \"test file 2\",\r\n      \"path\": \"folderName/test2.txt\",\r\n      \"size\": 1,\r\n      \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"createdDateTime\": \"2020-05-03T11:05:12.0133549Z\",\r\n      \"lastModifiedDateTime\": \"2020-05-03T11:05:12.0133549Z\",\r\n      \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n    }\r\n  ],\r\n  \"_links\": {\r\n    \"self\": {\r\n      \"href\": \"https://api.bentley.com/storage?projectId=6959daff-27f5-4b87-96ea-9917daa3a8ff&$skip=4&$top=2\"\r\n    },\r\n    \"prev\": {\r\n      \"href\": \"https://api.bentley.com/storage?projectId=6959daff-27f5-4b87-96ea-9917daa3a8ff&$skip=2&$top=2\"\r\n    },\r\n    \"next\": {\r\n      \"href\": \"https://api.bentley.com/storage?projectId=6959daff-27f5-4b87-96ea-9917daa3a8ff&$skip=6&$top=2\"\r\n    },\r\n    \"folder\": {\r\n      \"href\": \"https://api.bentley.com/storage/folders/TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n    }\r\n  }\r\n}\r\n"
+            }
+          },
+          "401": {
+            "description": "This response indicates that request lacks valid authentication credentials. Access token might not been provided, issued by the wrong issuer, does not have required scopes or request headers were malformed.",
+            "examples": {
+              "application/json": "{\n\r\"statusCode\": 401,\n\r\"message\": \"Access denied due to invalid access_token. Make sure to provide a valid token for this API endpoint.\"}"
+            }
+          },
+          "422": {
+            "description": "Invalid request to get top level folders and files",
+            "examples": {
+              "application/json": "{\r\n    \"error\": {\r\n        \"code\": \"InvalidStorageRequest\",\r\n        \"message\": \"Page size is over 1000 items limit.\"\r\n    }\r\n}"
+            }
+          },
+          "429": {
+            "description": "This response indicates that the user has sent too many requests in a given amount of time.",
+            "headers": {
+              "retry-after": {
+                "type": "string",
+                "description": "The number of requests exceeds the rate-limit for the client subscription."
+              }
+            },
+            "examples": {
+              "application/json": "{\n\r\"code\": \"TooManyRequests\",\n\r\"message\": \"More requests were received than the subscription rate-limit allows.\"}"
+            }
+          }
+        }
+      }
+    },
     "/recycleBin": {
       "get": {
-        "description": "---\r\n\r\nGet deleted files and folders\r\n\r\n### Authentication\r\n\r\nRequires *Authorization* header with valid Bearer token for scope *storage:read*.\r\n\r\n---",
+        "description": "---\r\n\r\nGet deleted files and folders\r\n\r\n### Authentication\r\n\r\nRequires `Authorization` header with valid Bearer token for scope `storage:read`.\r\n\r\n---",
         "operationId": "get-folders-and-files-in-recycle-bin",
         "summary": "Get folders and files in recycle bin",
         "tags": ["Folders", "Files"],
@@ -1198,14 +1435,14 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "OAuth access token with scope 'storage:read'",
+            "description": "OAuth access token with scope `storage:read`",
             "required": true,
             "type": "string"
           },
           {
             "name": "Accept",
             "in": "header",
-            "description": "RECOMMENDED. Request a specific version of iTwin Platform API.",
+            "description": "Setting to `application/vnd.bentley.itwin-platform.v1+json` is recommended.",
             "type": "string",
             "enum": ["application/vnd.bentley.itwin-platform.v1+json"]
           }
@@ -1228,7 +1465,7 @@
             }
           },
           "422": {
-            "description": "Invalid request to get projects",
+            "description": "Invalid request to get folders and files in recycle bin",
             "examples": {
               "application/json": "{\r\n    \"error\": {\r\n        \"code\": \"InvalidStorageRequest\",\r\n        \"message\": \"Page size is over 1000 items limit.\"\r\n    }\r\n}"
             }
@@ -1250,16 +1487,28 @@
     }
   },
   "definitions": {
-    "errors": {
+    "minimal-error": {
+      "title": "minimal error",
       "type": "object",
       "properties": {
-        "errors": {
-          "type": "array",
-          "items": {}
+        "self": {
+          "$ref": "#/definitions/error"
         }
       }
     },
-    "links (paging)": {
+    "error": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "code": {
+          "type": "string"
+        }
+      }
+    },
+    "links-paging": {
+      "title": "links (paging)",
       "type": "object",
       "properties": {
         "self": {
@@ -1313,7 +1562,8 @@
         }
       }
     },
-    "folder (typed)": {
+    "folder-typed": {
+      "title": "folder (typed)",
       "type": "object",
       "properties": {
         "id": {
@@ -1348,7 +1598,8 @@
         }
       }
     },
-    "folder (create)": {
+    "folder-create": {
+      "title": "folder (create)",
       "type": "object",
       "properties": {
         "displayName": {
@@ -1358,7 +1609,20 @@
           "type": "string"
         }
       },
-      "example": "{\r\n  \"folder\": {\r\n    \"displayName\": \"test\",\r\n    \"description\": \"test folder\"\r\n  }\r\n}\r\n"
+      "example": "{\r\n  \"displayName\": \"test\",\r\n  \"description\": \"test folder\"\r\n}\r\n"
+    },
+    "folder-update": {
+      "title": "folder (update)",
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "example": "{\r\n  \"displayName\": \"test\",\r\n  \"description\": \"test folder\"\r\n}\r\n"
     },
     "folders": {
       "type": "object",
@@ -1370,7 +1634,7 @@
           }
         },
         "_links": {
-          "$ref": "#/definitions/links (paging)"
+          "$ref": "#/definitions/links-paging"
         }
       }
     },
@@ -1409,7 +1673,8 @@
         }
       }
     },
-    "file (typed)": {
+    "file-typed": {
+      "title": "file (typed)",
       "type": "object",
       "properties": {
         "id": {
@@ -1447,7 +1712,8 @@
         }
       }
     },
-    "file (create)": {
+    "file-create": {
+      "title": "file (create)",
       "type": "object",
       "properties": {
         "displayName": {
@@ -1457,17 +1723,32 @@
           "type": "string"
         }
       },
-      "example": "{\r\n  \"file\": {\r\n    \"displayName\": \"test.txt\",\r\n    \"description\": \"test file\"\r\n  }\r\n}\r\n"
+      "example": "{\r\n  \"displayName\": \"test.txt\",\r\n  \"description\": \"test file\"\r\n}\r\n"
     },
-    "file (upload)": {
+    "file-update": {
+      "title": "file (update)",
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "example": "{\r\n  \"displayName\": \"test.txt\",\r\n  \"description\": \"test file\"\r\n}\r\n"
+    },
+    "file-upload": {
+      "title": "file-upload",
       "type": "object",
       "properties": {
         "_links": {
-          "$ref": "#/definitions/links (upload)"
+          "$ref": "#/definitions/links-upload"
         }
       }
     },
-    "links (upload)": {
+    "links-upload": {
+      "title": "links (upload)",
       "type": "object",
       "properties": {
         "uploadUrl": {
@@ -1488,7 +1769,7 @@
           }
         },
         "_links": {
-          "$ref": "#/definitions/links (paging)"
+          "$ref": "#/definitions/links-paging"
         }
       }
     },
@@ -1500,7 +1781,7 @@
           "items": {}
         },
         "_links": {
-          "$ref": "#/definitions/links (paging)"
+          "$ref": "#/definitions/links-paging"
         }
       }
     }

--- a/packages/app/src/api/synchronization/api.ts
+++ b/packages/app/src/api/synchronization/api.ts
@@ -22,7 +22,7 @@ import * as url from "url";
 
 import { Configuration } from "./configuration";
 
-export const BASE_PATH = "https://api.bentley.com/synchronization/v1".replace(
+export const BASE_PATH = "https://api.bentley.com/synchronization".replace(
   /\/+$/,
   ""
 );
@@ -776,6 +776,34 @@ export interface SourceFileCreate {
 /**
  *
  * @export
+ * @interface SourceFileCreatebody
+ */
+export interface SourceFileCreatebody {
+  /**
+   *
+   * @type {SourceFileCreate}
+   * @memberof SourceFileCreatebody
+   */
+  sourceFile?: SourceFileCreate;
+}
+
+/**
+ *
+ * @export
+ * @interface SourceFileCreated
+ */
+export interface SourceFileCreated {
+  /**
+   *
+   * @type {SourceFile}
+   * @memberof SourceFileCreated
+   */
+  sourceFile?: SourceFile;
+}
+
+/**
+ *
+ * @export
  * @interface SourceFileSummary
  */
 export interface SourceFileSummary {
@@ -906,7 +934,7 @@ export const DefaultApiFetchParamCreator = function(
      * @summary Add Connection SourceFile
      * @param {string} connectionId
      * @param {string} Authorization OAuth access token with scope &#39;connections:modify&#39;
-     * @param {SourceFileCreate} sourceFile__create
+     * @param {SourceFileCreatebody} sourceFile__create
      * @param {string} [imodelId] iModel Id
      * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
      * @param {*} [options] Override http request option.
@@ -915,7 +943,7 @@ export const DefaultApiFetchParamCreator = function(
     addConnectionSourcefile(
       connectionId: string,
       Authorization: string,
-      sourceFile__create: SourceFileCreate,
+      sourceFile__create: SourceFileCreatebody,
       imodelId?: string,
       Accept?: "application/vnd.bentley.itwin-platform.v1+json",
       options: any = {}
@@ -1009,7 +1037,7 @@ export const DefaultApiFetchParamCreator = function(
         options.headers
       );
       const needsSerialization =
-        <any>"SourceFileCreate" !== "string" ||
+        <any>"SourceFileCreatebody" !== "string" ||
         localVarRequestOptions.headers["Content-Type"] === "application/json";
       localVarRequestOptions.body = needsSerialization
         ? JSON.stringify(sourceFile__create || {})
@@ -2295,7 +2323,7 @@ export const DefaultApiFetchParamCreator = function(
      * @param {string} connectionId
      * @param {string} sourceFileId
      * @param {string} Authorization OAuth access token with scope &#39;connections:modify&#39;
-     * @param {SourceFileCreate} sourceFile__create
+     * @param {SourceFileCreatebody} sourceFile__create
      * @param {string} [imodelId] iModel Id
      * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
      * @param {*} [options] Override http request option.
@@ -2305,7 +2333,7 @@ export const DefaultApiFetchParamCreator = function(
       connectionId: string,
       sourceFileId: string,
       Authorization: string,
-      sourceFile__create: SourceFileCreate,
+      sourceFile__create: SourceFileCreatebody,
       imodelId?: string,
       Accept?: "application/vnd.bentley.itwin-platform.v1+json",
       options: any = {}
@@ -2411,7 +2439,7 @@ export const DefaultApiFetchParamCreator = function(
         options.headers
       );
       const needsSerialization =
-        <any>"SourceFileCreate" !== "string" ||
+        <any>"SourceFileCreatebody" !== "string" ||
         localVarRequestOptions.headers["Content-Type"] === "application/json";
       localVarRequestOptions.body = needsSerialization
         ? JSON.stringify(sourceFile__create || {})
@@ -2436,7 +2464,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
      * @summary Add Connection SourceFile
      * @param {string} connectionId
      * @param {string} Authorization OAuth access token with scope &#39;connections:modify&#39;
-     * @param {SourceFileCreate} sourceFile__create
+     * @param {SourceFileCreatebody} sourceFile__create
      * @param {string} [imodelId] iModel Id
      * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
      * @param {*} [options] Override http request option.
@@ -2445,11 +2473,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
     addConnectionSourcefile(
       connectionId: string,
       Authorization: string,
-      sourceFile__create: SourceFileCreate,
+      sourceFile__create: SourceFileCreatebody,
       imodelId?: string,
       Accept?: "application/vnd.bentley.itwin-platform.v1+json",
       options?: any
-    ): (fetch?: FetchAPI, basePath?: string) => Promise<SourceFile> {
+    ): (fetch?: FetchAPI, basePath?: string) => Promise<SourceFileCreated> {
       const localVarFetchArgs = DefaultApiFetchParamCreator(
         configuration
       ).addConnectionSourcefile(
@@ -2576,7 +2604,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
       Authorization: string,
       Accept?: "application/vnd.bentley.itwin-platform.v1+json",
       options?: any
-    ): (fetch?: FetchAPI, basePath?: string) => Promise<Connection> {
+    ): (fetch?: FetchAPI, basePath?: string) => Promise<ConnectionCreated> {
       const localVarFetchArgs = DefaultApiFetchParamCreator(
         configuration
       ).getConnection(connectionId, imodelId, Authorization, Accept, options);
@@ -2961,7 +2989,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
      * @param {string} connectionId
      * @param {string} sourceFileId
      * @param {string} Authorization OAuth access token with scope &#39;connections:modify&#39;
-     * @param {SourceFileCreate} sourceFile__create
+     * @param {SourceFileCreatebody} sourceFile__create
      * @param {string} [imodelId] iModel Id
      * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
      * @param {*} [options] Override http request option.
@@ -2971,7 +2999,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
       connectionId: string,
       sourceFileId: string,
       Authorization: string,
-      sourceFile__create: SourceFileCreate,
+      sourceFile__create: SourceFileCreatebody,
       imodelId?: string,
       Accept?: "application/vnd.bentley.itwin-platform.v1+json",
       options?: any
@@ -3021,7 +3049,7 @@ export const DefaultApiFactory = function(
      * @summary Add Connection SourceFile
      * @param {string} connectionId
      * @param {string} Authorization OAuth access token with scope &#39;connections:modify&#39;
-     * @param {SourceFileCreate} sourceFile__create
+     * @param {SourceFileCreatebody} sourceFile__create
      * @param {string} [imodelId] iModel Id
      * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
      * @param {*} [options] Override http request option.
@@ -3030,7 +3058,7 @@ export const DefaultApiFactory = function(
     addConnectionSourcefile(
       connectionId: string,
       Authorization: string,
-      sourceFile__create: SourceFileCreate,
+      sourceFile__create: SourceFileCreatebody,
       imodelId?: string,
       Accept?: "application/vnd.bentley.itwin-platform.v1+json",
       options?: any
@@ -3352,7 +3380,7 @@ export const DefaultApiFactory = function(
      * @param {string} connectionId
      * @param {string} sourceFileId
      * @param {string} Authorization OAuth access token with scope &#39;connections:modify&#39;
-     * @param {SourceFileCreate} sourceFile__create
+     * @param {SourceFileCreatebody} sourceFile__create
      * @param {string} [imodelId] iModel Id
      * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
      * @param {*} [options] Override http request option.
@@ -3362,7 +3390,7 @@ export const DefaultApiFactory = function(
       connectionId: string,
       sourceFileId: string,
       Authorization: string,
-      sourceFile__create: SourceFileCreate,
+      sourceFile__create: SourceFileCreatebody,
       imodelId?: string,
       Accept?: "application/vnd.bentley.itwin-platform.v1+json",
       options?: any
@@ -3392,7 +3420,7 @@ export class DefaultApi extends BaseAPI {
    * @summary Add Connection SourceFile
    * @param {string} connectionId
    * @param {string} Authorization OAuth access token with scope &#39;connections:modify&#39;
-   * @param {SourceFileCreate} sourceFile__create
+   * @param {SourceFileCreatebody} sourceFile__create
    * @param {string} [imodelId] iModel Id
    * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
    * @param {*} [options] Override http request option.
@@ -3402,7 +3430,7 @@ export class DefaultApi extends BaseAPI {
   public addConnectionSourcefile(
     connectionId: string,
     Authorization: string,
-    sourceFile__create: SourceFileCreate,
+    sourceFile__create: SourceFileCreatebody,
     imodelId?: string,
     Accept?: "application/vnd.bentley.itwin-platform.v1+json",
     options?: any
@@ -3747,7 +3775,7 @@ export class DefaultApi extends BaseAPI {
    * @param {string} connectionId
    * @param {string} sourceFileId
    * @param {string} Authorization OAuth access token with scope &#39;connections:modify&#39;
-   * @param {SourceFileCreate} sourceFile__create
+   * @param {SourceFileCreatebody} sourceFile__create
    * @param {string} [imodelId] iModel Id
    * @param {'application/vnd.bentley.itwin-platform.v1+json'} [Accept] RECOMMENDED. Request a specific version of iTwin Platform API.
    * @param {*} [options] Override http request option.
@@ -3758,7 +3786,7 @@ export class DefaultApi extends BaseAPI {
     connectionId: string,
     sourceFileId: string,
     Authorization: string,
-    sourceFile__create: SourceFileCreate,
+    sourceFile__create: SourceFileCreatebody,
     imodelId?: string,
     Accept?: "application/vnd.bentley.itwin-platform.v1+json",
     options?: any

--- a/packages/app/src/api/synchronizationApiUtils.ts
+++ b/packages/app/src/api/synchronizationApiUtils.ts
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import {
+  DefaultApi as SynchronizeApi,
+  IModelBridgeType,
+} from "./synchronization/api";
+
+const DEMO_CONNECTION_NAME = "demo-portal-imodel-connection";
+
+export const extractIdsFromLastRunDetails = (href: string | undefined) => {
+  console.log(href);
+  if (!href) {
+    return [];
+  }
+  if (href.includes("/runs/")) {
+    return href?.split("/connections/")[1]?.split("/runs/") ?? [];
+  }
+
+  return href?.split("runs")[1]?.split("/") ?? [];
+};
+
+export const getDemoConnectionAndSourceFiles = async (
+  iModelId: string,
+  accessToken: string,
+  synchronizeApi: SynchronizeApi
+) => {
+  const connections = await synchronizeApi.getConnections(
+    iModelId,
+    accessToken
+  );
+  const demoPortalConnection = connections.connections?.find(
+    (connection) => connection.displayName === DEMO_CONNECTION_NAME
+  );
+  const sourceFiles = demoPortalConnection?.id
+    ? (
+        await synchronizeApi.getConnectionSourcefiles(
+          demoPortalConnection.id,
+          accessToken,
+          iModelId,
+          undefined,
+          {
+            headers: { Prefer: "return=representation" },
+          }
+        )
+      ).sourceFiles ?? []
+    : [];
+
+  return {
+    connection: demoPortalConnection,
+    sourceFiles,
+  };
+};
+
+export const addFileToDemoConnection = async (
+  demoConnectionId: string | undefined,
+  fileId: string,
+  bridgeType: IModelBridgeType,
+  iModelId: string,
+  projectId: string,
+  email: string,
+  accessToken: string,
+  api: SynchronizeApi
+) => {
+  if (!demoConnectionId) {
+    const fileConnection = await api.createConnection(iModelId, accessToken, {
+      connection: {
+        ownerEmail: email.toLocaleLowerCase(),
+        displayName: DEMO_CONNECTION_NAME,
+        sourceFiles: [
+          {
+            fileId,
+            isSpatialRoot: false,
+            iModelBridgeType: bridgeType,
+          },
+        ],
+        projectShareLocation: {
+          projectId,
+        },
+      },
+    });
+    if (!fileConnection.connection?.id) {
+      throw new Error("Connection creation failed");
+    }
+    return fileConnection.connection.id;
+  }
+  const addedFile = await api.addConnectionSourcefile(
+    demoConnectionId,
+    accessToken,
+    {
+      sourceFile: {
+        fileId,
+        isSpatialRoot: false,
+        iModelBridgeType: bridgeType,
+      },
+    },
+    iModelId
+  );
+  if (!addedFile.sourceFile?.id) {
+    throw new Error("Updating creation failed");
+  }
+  return demoConnectionId;
+};

--- a/packages/app/src/api/synchronizationOpenAPI.json
+++ b/packages/app/src/api/synchronizationOpenAPI.json
@@ -6,7 +6,7 @@
     "description": "iModel Connections API is a cloud-based synchronization API meant to synchronize the data in Input Files and iModels. It allows users to establish links from their design files to iModels, hosted in Bentley's iModelHub. Users can setup recurring synchronization to periodically synchronize updates to their design files, or manual synchronizations."
   },
   "host": "api.bentley.com",
-  "basePath": "/synchronization/v1",
+  "basePath": "/synchronization",
   "schemes": ["https"],
   "securityDefinitions": {
     "apiKeyHeader": {
@@ -155,7 +155,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/SourceFile (create)"
+              "$ref": "#/definitions/SourceFile (createbody)"
             }
           }
         ],
@@ -169,7 +169,7 @@
           "201": {
             "description": "Connection sourceFile successfully added.",
             "schema": {
-              "$ref": "#/definitions/SourceFile"
+              "$ref": "#/definitions/SourceFile (created)"
             },
             "examples": {
               "application/json": "{\r\n  \"sourceFile\": {\r\n      \"id\": \"297c8ab9-53a3-4fe5-adf8-79b4c1a95cbb\",\r\n      \"isSpatialRoot\": true,\r\n      \"lastAddedToConnectionRunDateTime\": \"2020-10-24T02:44:13.4109666Z\",\r\n      \"iModelBridgeType\": \"MSTN\",\r\n      \"createdDateTime\": \"2020-11-17T11:37:55.518838Z\",\r\n      \"lastModifiedDateTime\": \"2020-11-17T11:37:55.518838Z\",\r\n      \"persistenceType\": \"Persistent\",\r\n      \"lastKnownFileName\": \"samplefile\",\r\n      \"executionAction\": \"Bridge\",\r\n      \"_links\": {\r\n        \"file\": {\r\n          \"href\": \"https://api.bentley.com/files/5db42812-ebb8-4c58-98a4-2eaa99e0d8b6\"\r\n        }\r\n      }\r\n  }\r\n}"
@@ -326,7 +326,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/SourceFile (create)"
+              "$ref": "#/definitions/SourceFile (createbody)"
             }
           }
         ],
@@ -671,7 +671,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/Connection"
+              "$ref": "#/definitions/Connection (created)"
             },
             "examples": {
               "application/json": "{\r\n  \"connection\": {\r\n    \"id\": \"fc226d0d-1647-48d7-8c11-f1f74f2d9808\",\r\n    \"displayName\": \"30\",\r\n    \"isScheduled\": true,\r\n    \"isSchedulePaused\": false,\r\n    \"scheduleLoopIntervalInSeconds\": 1800,\r\n    \"scheduledDateTime\": \"2020-10-24T02:44:13.4109666Z\",\r\n    \"priorityLevel\": \"Low\",\r\n    \"createdDateTime\": \"2020-10-24T02:26:51.1366301Z\",\r\n    \"lastModifiedDateTime\": \"2020-11-10T14:50:03.1175774Z\",\r\n    \"persistenceType\": \"Persistent\",\r\n    \"bridgeParameters\": null,\r\n    \"_links\": {\r\n      \"iModel\": {\r\n        \"href\": \"https://api.bentley.com/imodels/5db42812-ebb8-4c58-98a4-2eaa99e0d8b6\"\r\n      },\r\n      \"projectShareLocation\": {\r\n        \"href\": \"https://api.bentley.com/projects/4tb42812-ebb8-4c58-98a4-2eaa99e0d8b6\"\r\n      },\r\n      \"lastRunDetails\": {\r\n        \"href\": \"https://api.bentley.com/synchronization/imodels/connections/fc226d0d-1647-48d7-8c11-f1f74f2d9808/runs/de626d0d-1647-48d7-8c11-f1f74f2d4523\"\r\n      }\r\n    }\r\n  }\r\n}"
@@ -1568,6 +1568,22 @@
         "fileId": {
           "description": "",
           "type": "string"
+        }
+      }
+    },
+    "SourceFile (createbody)": {
+      "type": "object",
+      "properties": {
+        "sourceFile": {
+          "$ref": "#/definitions/SourceFile (create)"
+        }
+      }
+    },
+    "SourceFile (created)": {
+      "type": "object",
+      "properties": {
+        "sourceFile": {
+          "$ref": "#/definitions/SourceFile"
         }
       }
     },

--- a/packages/app/src/components/SynchronizationRouter/Synchronize.tsx
+++ b/packages/app/src/components/SynchronizationRouter/Synchronize.tsx
@@ -33,19 +33,13 @@ import {
   ExecutionResult,
   ExecutionState,
 } from "../../api/synchronization";
+import { extractIdsFromLastRunDetails } from "../../api/synchronizationApiUtils";
 import { useApiPrefix, usePrefixedUrl } from "../../api/useApiPrefix";
 import "./Synchronize.scss";
 import { useSynchronizeFileUploader } from "./useSynchronizeFileUploader";
 
 type CreateTypeFromInterface<Interface> = {
   [Property in keyof Interface]: Interface[Property];
-};
-
-const extractIdsFromLastRunDetails = (href: string | undefined) => {
-  if (!href) {
-    return [];
-  }
-  return href.split("runs")[1]?.split("/") ?? [];
 };
 
 const getAlertType = (state: string) =>


### PR DESCRIPTION
# Single demo connection

In that PR, we now only ever create 1 connection, instead of one connection per file

## Rushed...

While the main feature is there, the UI have not been updated (Synchronize only display one connection, not the files) The reason for this is that API changes were made in storage that would make the live site dead for connection purposes, so I send here this updated feature along the 1 file change, that will also generate less "backward compatibility" issues.

## Known issues

### Unauthorized error

While in Dev the connection have been updated to handle our users, the user still need to access at least once the real portal so they can "steal" the user's token. This will need a real solution, but, it's there, in any other environment, user still must be updated manually, by going to the real portal, which mitigates the other issue...

### No refresh mechanism

When running a connection, the UI will refresh instantly, but never again, so, to see actual progress, the user need to manually hit F5.

### No file details

As mentionned above, the UI is not displaying the list of files linked, it will in an upcoming update and completely hide the "demo-portal-imodel-connection" from the user.