### PR TITLE
Reduce unnecessary network traffic

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -33,8 +33,8 @@
     "@itwin/create-imodel-react": "^0.2.1",
     "@itwin/delete-imodel-react": "^0.2.0",
     "@itwin/imodel-browser-react": "^0.10.3",
-    "@itwin/itwinui-icons-react": "^1.1.2",
     "@itwin/itwinui-css": "^0.18.1",
+    "@itwin/itwinui-icons-react": "^1.1.2",
     "@itwin/itwinui-react": "^1.7.2",
     "@reach/router": "^1.3.4",
     "@svgr/webpack": "4.3.3",
@@ -52,6 +52,7 @@
     "portable-fetch": "^3.0.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
+    "react-intersection-observer": "^8.32.0",
     "typescript": "^3.7.2"
   },
   "scripts": {

--- a/packages/app/src/api/storage/generated/api.ts
+++ b/packages/app/src/api/storage/generated/api.ts
@@ -636,6 +636,58 @@ export interface MinimalError {
 }
 
 /**
+ *
+ * @export
+ * @interface TopItems
+ */
+export interface TopItems {
+  /**
+   *
+   * @type {Array<any>}
+   * @memberof TopItems
+   */
+  items?: Array<any>;
+  /**
+   *
+   * @type {TopLinksPaging}
+   * @memberof TopItems
+   */
+  _links?: TopLinksPaging;
+}
+
+/**
+ *
+ * @export
+ * @interface TopLinksPaging
+ */
+export interface TopLinksPaging {
+  /**
+   *
+   * @type {Link}
+   * @memberof TopLinksPaging
+   */
+  self?: Link;
+  /**
+   *
+   * @type {Link}
+   * @memberof TopLinksPaging
+   */
+  next?: Link;
+  /**
+   *
+   * @type {Link}
+   * @memberof TopLinksPaging
+   */
+  prev?: Link;
+  /**
+   *
+   * @type {Link}
+   * @memberof TopLinksPaging
+   */
+  folder?: Link;
+}
+
+/**
  * FilesApi - fetch parameter creator
  * @export
  */
@@ -2356,7 +2408,7 @@ export const FilesApiFp = function(configuration?: Configuration) {
       skip?: number,
       Accept?: "application/vnd.bentley.itwin-platform.v1+json",
       options?: any
-    ): (fetch?: FetchAPI, basePath?: string) => Promise<Items> {
+    ): (fetch?: FetchAPI, basePath?: string) => Promise<TopItems> {
       const localVarFetchArgs = FilesApiFetchParamCreator(
         configuration
       ).getTopLevelFoldersAndFilesByProject(
@@ -4662,7 +4714,7 @@ export const FoldersApiFp = function(configuration?: Configuration) {
       skip?: number,
       Accept?: "application/vnd.bentley.itwin-platform.v1+json",
       options?: any
-    ): (fetch?: FetchAPI, basePath?: string) => Promise<Items> {
+    ): (fetch?: FetchAPI, basePath?: string) => Promise<TopItems> {
       const localVarFetchArgs = FoldersApiFetchParamCreator(
         configuration
       ).getTopLevelFoldersAndFilesByProject(

--- a/packages/app/src/api/storage/openapi/storageAdjusted.json
+++ b/packages/app/src/api/storage/openapi/storageAdjusted.json
@@ -1373,7 +1373,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/items"
+              "$ref": "#/definitions/top-items"
             },
             "examples": {
               "application/json": "{\r\n  \"items\": [\r\n    {\r\n      \"type\": \"folder\",\r\n      \"id\": \"TYJsPN0xtkWId0yUrXkS5pN5AQzuullIkxz5aDnDJSI\",\r\n      \"displayName\": \"test\",\r\n      \"description\": \"test folder\",\r\n      \"path\": \"folderName/test\",\r\n      \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"createdDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n      \"lastModifiedDateTime\": \"2020-05-03T11:05:11.0133549Z\",\r\n      \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n    },\r\n    {\r\n      \"type\": \"file\",\r\n      \"id\": \"TYJsPN0xtkWId0yUrXkS5s4FlCroosBMlyDhZZmlzoc\",\r\n      \"displayName\": \"test2.txt\",\r\n      \"description\": \"test file 2\",\r\n      \"path\": \"folderName/test2.txt\",\r\n      \"size\": 1,\r\n      \"createdBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"lastModifiedBy\": \"1140f95b-1ba0-49d9-bbf4-b53e54d80387\",\r\n      \"createdDateTime\": \"2020-05-03T11:05:12.0133549Z\",\r\n      \"lastModifiedDateTime\": \"2020-05-03T11:05:12.0133549Z\",\r\n      \"parentFolderId\": \"TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n    }\r\n  ],\r\n  \"_links\": {\r\n    \"self\": {\r\n      \"href\": \"https://api.bentley.com/storage?projectId=6959daff-27f5-4b87-96ea-9917daa3a8ff&$skip=4&$top=2\"\r\n    },\r\n    \"prev\": {\r\n      \"href\": \"https://api.bentley.com/storage?projectId=6959daff-27f5-4b87-96ea-9917daa3a8ff&$skip=2&$top=2\"\r\n    },\r\n    \"next\": {\r\n      \"href\": \"https://api.bentley.com/storage?projectId=6959daff-27f5-4b87-96ea-9917daa3a8ff&$skip=6&$top=2\"\r\n    },\r\n    \"folder\": {\r\n      \"href\": \"https://api.bentley.com/storage/folders/TYJsPN0xtkWId0yUrXkS5g0CIYaGZLxEozrWBCOcS_s\"\r\n    }\r\n  }\r\n}\r\n"
@@ -1518,6 +1518,24 @@
           "$ref": "#/definitions/link"
         },
         "prev": {
+          "$ref": "#/definitions/link"
+        }
+      }
+    },
+    "top-links-paging": {
+      "title": "links (paging)",
+      "type": "object",
+      "properties": {
+        "self": {
+          "$ref": "#/definitions/link"
+        },
+        "next": {
+          "$ref": "#/definitions/link"
+        },
+        "prev": {
+          "$ref": "#/definitions/link"
+        },
+        "folder": {
           "$ref": "#/definitions/link"
         }
       }
@@ -1801,6 +1819,18 @@
         },
         "_links": {
           "$ref": "#/definitions/links-paging"
+        }
+      }
+    },
+    "top-items": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {}
+        },
+        "_links": {
+          "$ref": "#/definitions/top-links-paging"
         }
       }
     }

--- a/packages/app/src/api/storage/storageClient.ts
+++ b/packages/app/src/api/storage/storageClient.ts
@@ -73,16 +73,34 @@ export class StorageClient {
    * Retrieves the id of the folder named "demo-portal-imodel-connections" in the provided folder.
    * Note that this will cache retrieved value and not return to the network as these are not
    * expected to change through the lifetime of the project.
-   * @param projectFolderId Found by calling getProject api.
+   * @param projectId
    * @param createIfNotFound
    * @returns A storage api folderID if found or createIfNotFound is true, an empty string otherwise.
    */
-  async getDemoFolderId(projectFolderId: string, createIfNotFound: boolean) {
-    return this.getFolderIdByName(
-      projectFolderId,
-      this.DEMO_FOLDER_NAME,
-      createIfNotFound
+  async getDemoFolderId(projectId: string, createIfNotFound: boolean) {
+    const projectInfo = await this.foldersApi.getTopLevelFoldersAndFilesByProject(
+      projectId,
+      this.accessToken,
+      1000,
+      0,
+      "application/vnd.bentley.itwin-platform.v1+json"
     );
+    const topFolderId = projectInfo._links?.folder?.href
+      ?.split("/")
+      .reverse()[0];
+    const demoFolder = projectInfo.items?.find(
+      (folder) => folder.displayName === this.DEMO_FOLDER_NAME
+    );
+    if (demoFolder) {
+      return demoFolder.id;
+    }
+    if (topFolderId) {
+      return this.getFolderIdByName(
+        topFolderId,
+        this.DEMO_FOLDER_NAME,
+        createIfNotFound
+      );
+    }
   }
 
   /**

--- a/packages/app/src/components/SelectionRouter/SelectIModel.tsx
+++ b/packages/app/src/components/SelectionRouter/SelectIModel.tsx
@@ -2,16 +2,11 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import {
-  IModelGrid,
-  IModelGridProps,
-  ProjectFull,
-} from "@itwin/imodel-browser-react";
-import { ButtonGroup, Title } from "@itwin/itwinui-react";
+import { IModelGrid, IModelGridProps } from "@itwin/imodel-browser-react";
+import { ButtonGroup } from "@itwin/itwinui-react";
 import { RouteComponentProps } from "@reach/router";
 import React from "react";
 
-import { useApiData } from "../../api/useApiData";
 import { useApiPrefix } from "../../api/useApiPrefix";
 import { useCreateIModelAction } from "../IModelCRUDRouter/useCreateIModelAction";
 import { useDeleteIModelAction } from "../IModelCRUDRouter/useDeleteIModelAction";
@@ -23,10 +18,7 @@ import {
 import { useSynchronizeIModelAction } from "../SynchronizationRouter/useSynchronizeIModelAction";
 import { useViewIModelAction } from "../ViewRouter/useViewIModelAction";
 import "./SelectIModel.scss";
-
-interface GetProjectResult {
-  project?: ProjectFull;
-}
+import { SelectIModelTitle } from "./SelectIModelTitle";
 
 type IModelRouteProps = RouteComponentProps<
   IModelGridProps & {
@@ -36,16 +28,12 @@ type IModelRouteProps = RouteComponentProps<
 >;
 export const SelectIModel = ({
   accessToken = "",
-  projectId,
+  projectId = "",
   navigate,
   hideActions,
   email,
   ...rest
 }: IModelRouteProps) => {
-  const { results } = useApiData<GetProjectResult>({
-    accessToken,
-    url: `https://api.bentley.com/projects/${projectId}`,
-  });
   const { deleteAction, deleteDialog, refreshKey } = useDeleteIModelAction({
     accessToken,
   });
@@ -57,11 +45,7 @@ export const SelectIModel = ({
   return (
     <div className="scrolling-tab-container">
       <div className={"title-section"}>
-        <Title>
-          {results?.project
-            ? `iModels for ${results?.project?.displayName}`
-            : "\u00a0"}
-        </Title>
+        <SelectIModelTitle accessToken={accessToken} projectId={projectId} />
         <ButtonGroup>{createIconButton}</ButtonGroup>
       </div>
       <div className="scrolling-tab-content">

--- a/packages/app/src/components/SelectionRouter/SelectIModelTitle.tsx
+++ b/packages/app/src/components/SelectionRouter/SelectIModelTitle.tsx
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { ProjectFull } from "@itwin/imodel-browser-react";
+import { Title } from "@itwin/itwinui-react";
+import React from "react";
+
+import { useApiData } from "../../api/useApiData";
+
+interface GetProjectResult {
+  project?: ProjectFull;
+}
+
+interface SelectIModelTitleProps {
+  accessToken: string;
+  projectId: string;
+}
+
+export const SelectIModelTitle = ({
+  accessToken,
+  projectId,
+}: SelectIModelTitleProps) => {
+  const { results } = useApiData<GetProjectResult>({
+    accessToken,
+    url: `https://api.bentley.com/projects/${projectId}`,
+  });
+
+  return (
+    <Title>
+      {results?.project
+        ? `iModels for ${results?.project?.displayName}`
+        : "\u00a0"}
+    </Title>
+  );
+};

--- a/packages/app/src/components/SynchronizationRouter/useSynchronizeFileUploader.ts
+++ b/packages/app/src/components/SynchronizationRouter/useSynchronizeFileUploader.ts
@@ -7,7 +7,6 @@ import React, { ComponentPropsWithoutRef } from "react";
 
 import { StorageClient } from "../../api/storage/storageClient";
 import { SynchronizationClient } from "../../api/synchronization/synchronizationClient";
-import { ProjectWithLinks, useApiData } from "../../api/useApiData";
 import { useApiPrefix } from "../../api/useApiPrefix";
 
 interface ConnectionFileUploaderOptions {
@@ -32,15 +31,6 @@ export const useSynchronizeFileUploader = ({
   email = "",
 }: ConnectionFileUploaderOptions) => {
   const urlPrefix = useApiPrefix();
-  const { results } = useApiData<{ project: ProjectWithLinks }>({
-    url: projectId
-      ? `https://api.bentley.com/projects/${projectId}`
-      : undefined,
-    accessToken,
-  });
-
-  const storageLinkHref = results?.project?._links?.storage?.href;
-
   const [step, setStep] = React.useState(0);
   const [status, setStatus] = React.useState<string | undefined>();
   const [progress, setProgress] = React.useState(0);
@@ -60,14 +50,6 @@ export const useSynchronizeFileUploader = ({
         }
         if (email === "") {
           throw new Error("User email required, none provided");
-        }
-        const projectFolderId = StorageClient.extractFolderIdFromStorageHref(
-          storageLinkHref
-        );
-        if (!projectFolderId) {
-          throw new Error(
-            "Project folder could not be determined, please refresh the page"
-          );
         }
 
         if (fileList.length > 1) {
@@ -108,10 +90,7 @@ export const useSynchronizeFileUploader = ({
         setStep(2);
         setStatus("Validating demo portal file share");
         const storage = new StorageClient(urlPrefix, accessToken);
-        const demoFolderId = await storage.getDemoFolderId(
-          projectFolderId,
-          true
-        );
+        const demoFolderId = await storage.getDemoFolderId(projectId, true);
         setStatus("Validating iModel file share");
         const iModelFolderId = await storage.getIModelFolderId(
           demoFolderId,
@@ -185,7 +164,7 @@ export const useSynchronizeFileUploader = ({
         setState("Error");
       }
     },
-    [accessToken, email, iModelId, projectId, storageLinkHref, urlPrefix]
+    [accessToken, email, iModelId, projectId, urlPrefix]
   );
   const resetUploader = () => {
     setStep(0);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3272,13 +3272,6 @@ axe-core@^4.0.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.2.2.tgz#0c987d82c8b82b4b9b7a945f1b5ef0d8fed586ed"
   integrity sha512-OKRkKM4ojMEZRJ5UNJHmq9tht7cEnRnqKG6KyB/trYws00Xtkv12mHtlJ0SK7cmuNbrU8dPUova3ELTuilfBbw==
 
-axios@0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
-  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
-  dependencies:
-    follow-redirects "^1.10.0"
-
 axobject-query@^2.0.2, axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -5221,7 +5214,7 @@ domhandler@^4.0.0, domhandler@^4.2.0:
   dependencies:
     domelementtype "^2.2.0"
 
-dompurify@^2.0.12, dompurify@^2.1.0:
+dompurify@^2.0.12:
   version "2.2.9"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.2.9.tgz#4b42e244238032d9286a0d2c87b51313581d9624"
   integrity sha512-+9MqacuigMIZ+1+EwoEltogyWGFTJZWU3258Rupxs+2CGs4H914G9er6pZbsme/bvb5L67o2rade9n21e4RW/w==
@@ -6099,7 +6092,14 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
-faye-websocket@^0.10.0, faye-websocket@^0.11.0, faye-websocket@~0.11.1:
+faye-websocket@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.10.0.tgz#4e492f8d04dfb6f89003507f6edbf2d501e7c6f4"
+  integrity sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=
+  dependencies:
+    websocket-driver ">=0.5.1"
+
+faye-websocket@~0.11.1:
   version "0.11.4"
   resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.4.tgz#7f0d9275cfdd86a1c963dc8b65fcc451edcbb1da"
   integrity sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==
@@ -6302,7 +6302,7 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.0.0, follow-redirects@^1.10.0:
+follow-redirects@^1.0.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
   integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
@@ -9679,11 +9679,6 @@ object-keys@^1.0.12, object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object-path@^0.11.5:
-  version "0.11.5"
-  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.5.tgz#d4e3cf19601a5140a55a16ad712019a9c50b577a"
-  integrity sha512-jgSbThcoR/s+XumvGMTMf81QVBmah+/Q7K7YduKeKVWL7N111unR2d6pZZarSk6kY/caeNxUDyxOvMWyzoU2eg==
-
 object-visit@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
@@ -11475,7 +11470,7 @@ react-input-autosize@^2.2.2:
   dependencies:
     prop-types "^15.5.8"
 
-react-intersection-observer@^8.31.1:
+react-intersection-observer@^8.31.1, react-intersection-observer@^8.32.0:
   version "8.32.0"
   resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.32.0.tgz#47249332e12e8bb99ed35a10bb7dd10446445a7b"
   integrity sha512-RlC6FvS3MFShxTn4FHAy904bVjX5Nn4/eTjUkurW0fHK+M/fyQdXuyCy9+L7yjA+YMGogzzSJNc7M4UtfSKvtw==
@@ -13733,11 +13728,6 @@ typescript@^3.7.2, typescript@^3.8.0:
   version "3.9.9"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
   integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
-
-ua-parser-js@^0.7.22:
-  version "0.7.28"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
-  integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
 
 uc.micro@^1.0.1:
   version "1.0.6"


### PR DESCRIPTION
# Network optimizations

Reduced the number of network calls in many different area

## useApiData share fetch

This hook already had a cache, but if multiple queries were made at the same time, the cache would be missed and multiple queries would be sent, asking for the same data. Now I also cache the fetch request itself, and return it's promise if a second query is made to the same url, (so they all resolve at the same time, but to different effect)

## getDemoFolderId no longer require getProjects

Due to a new API available in the storage API, it is now possible to request root folders for a projectId, rather than always relying on the root folder id, this enable skipping that network call. If the folder is not found on the first call, I still go searching "manually", using the root folder id returned by the api. (We could switch to the Search at this point, but I did not change that yet, scopes must be limited and this already fires in many direction)

## SelectIModelTitle

This one caught me by surprise, using the `useApiData` right in the `SelectIModel` component actually causes the full component to refresh, so there was a flicker when opening that page, so I moved that logic to a separate component, so only the title refreshes. (I think there is something wrong in the useApiData hook, it should probably never query for data immediately, but I'll look into this later)

## useSynchronizationInfo only when tile is in view

Added `react-intersection-observer` to only query for synchronization data when the tile is visible, so large project like DesignReviewTestData will be a litte lighter when opening the view...