### PR TITLE
Add manage version path and features

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -35,6 +35,7 @@
     "@itwin/imodel-browser-react": "^0.10.3",
     "@itwin/itwinui-css": "^0.18.1",
     "@itwin/itwinui-icons-react": "^1.1.2",
+    "@itwin/manage-versions-react": "^0.5.0",
     "@itwin/itwinui-react": "^1.9.0",
     "@reach/router": "^1.3.4",
     "@svgr/webpack": "4.3.3",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -11,6 +11,7 @@ import AuthorizationClient from "./AuthorizationClient";
 import { Header } from "./components/Header/Header";
 import MainContainer from "./components/MainLayout/MainContainer";
 import { Sidebar } from "./components/MainLayout/Sidebar";
+import { ManageVersionsRouter } from "./components/ManageVersionsRouter/ManageVersionsRouter";
 import { StayTunedRouter } from "./components/StayTunedRouter/StayTunedRouter";
 import { SynchronizationRouter } from "./components/SynchronizationRouter/SynchronizationRouter";
 import { ViewRouter } from "./components/ViewRouter/ViewRouter";
@@ -108,6 +109,11 @@ const App: React.FC = () => {
               />
               <SynchronizationRouter
                 path="synchronize/*"
+                accessToken={accessToken}
+                email={accessTokenObject?.getUserInfo()?.email?.id ?? ""}
+              />
+              <ManageVersionsRouter
+                path="manage-versions/*"
                 accessToken={accessToken}
                 email={accessTokenObject?.getUserInfo()?.email?.id ?? ""}
               />

--- a/packages/app/src/components/MainLayout/Sidebar.tsx
+++ b/packages/app/src/components/MainLayout/Sidebar.tsx
@@ -7,9 +7,9 @@ import {
   SvgCloud,
   SvgCompare,
   SvgDatabase,
+  SvgFlag,
   SvgReports,
   SvgSync,
-  SvgValidate,
 } from "@itwin/itwinui-icons-react";
 import { SidenavButton, SideNavigation } from "@itwin/itwinui-react";
 import { RouteComponentProps, Router } from "@reach/router";
@@ -53,12 +53,12 @@ export const RoutedSidebar = ({ navigate }: RouteComponentProps) => {
           Synchronize
         </SidenavButton>,
         <SidenavButton
-          key="validate"
-          startIcon={<SvgValidate />}
-          onClick={() => navigate?.(`/validate${selectionPath}`)}
-          isActive={section === "validate"}
+          key="manage-versions"
+          startIcon={<SvgFlag />}
+          onClick={() => navigate?.(`/manage-versions${selectionPath}`)}
+          isActive={section === "manage-versions"}
         >
-          Validate iModel Data
+          Manage Versions
         </SidenavButton>,
         <SidenavButton
           key="compare"

--- a/packages/app/src/components/ManageVersionsRouter/ManageVersions.scss
+++ b/packages/app/src/components/ManageVersionsRouter/ManageVersions.scss
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+@import "@itwin/itwinui-css/scss/variables";
+
+.manage-versions-with-side-and-splitter {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+
+  > div {
+    display: flex;
+    height: 100%;
+    flex-direction: column;
+
+    > * {
+      padding-left: calc(var(--responsive-grid-margin, 64px) - 3px);
+      padding-right: calc(var(--responsive-grid-margin, 64px) - 3px);
+    }
+
+    > ul + * {
+      margin-top: -9px;
+      padding-top: 9px;
+      overflow: auto;
+      flex-basis: 100%;
+      @include themed {
+        border-top: 2px solid t(iui-color-background-5);
+      }
+    }
+  }
+}

--- a/packages/app/src/components/ManageVersionsRouter/ManageVersions.tsx
+++ b/packages/app/src/components/ManageVersionsRouter/ManageVersions.tsx
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { ManageVersions as ACRManageVersions } from "@itwin/manage-versions-react";
+import { RouteComponentProps } from "@reach/router";
+import React from "react";
+
+import { useApiPrefix } from "../../api/useApiPrefix";
+import "./ManageVersions.scss";
+
+export interface VersionsProps extends RouteComponentProps {
+  iModelId?: string;
+  accessToken: string;
+}
+export const ManageVersions = ({
+  iModelId = "",
+  accessToken,
+}: VersionsProps) => {
+  const serverEnvironmentPrefix = useApiPrefix();
+
+  return (
+    <div className="manage-versions-with-side-and-splitter">
+      <ACRManageVersions
+        accessToken={accessToken}
+        imodelId={iModelId}
+        apiOverrides={{ serverEnvironmentPrefix }}
+      />
+    </div>
+  );
+};

--- a/packages/app/src/components/ManageVersionsRouter/ManageVersionsRouter.tsx
+++ b/packages/app/src/components/ManageVersionsRouter/ManageVersionsRouter.tsx
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { RouteComponentProps, Router } from "@reach/router";
+import React from "react";
+
+import { SelectionRouter } from "../SelectionRouter/SelectionRouter";
+import { ManageVersions } from "./ManageVersions";
+
+interface ManageVersionsRouterProps extends RouteComponentProps {
+  accessToken: string;
+  email: string;
+}
+
+export const ManageVersionsRouter = ({
+  accessToken,
+  email,
+}: ManageVersionsRouterProps) => {
+  return (
+    <Router className="router">
+      <SelectionRouter
+        accessToken={accessToken}
+        email={email}
+        path="*"
+        hideIModelActions={["manage-versions"]}
+      />
+      <ManageVersions
+        accessToken={accessToken}
+        path="project/:projectId/imodel/:iModelId"
+      />
+    </Router>
+  );
+};

--- a/packages/app/src/components/ManageVersionsRouter/useManageVersionsIModelAction.tsx
+++ b/packages/app/src/components/ManageVersionsRouter/useManageVersionsIModelAction.tsx
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { IModelFull } from "@itwin/create-imodel-react";
+import { SvgFlag } from "@itwin/itwinui-icons-react";
+import { useNavigate } from "@reach/router";
+import React from "react";
+
+export const useManageVersionsIModelAction = () => {
+  const navigate = useNavigate();
+  return {
+    manageVersionsAction: React.useMemo(
+      () => ({
+        key: "manage-versions",
+        icon: <SvgFlag />,
+        onClick: (iModel: IModelFull) =>
+          void navigate(
+            `/manage-versions/project/${iModel.projectId}/imodel/${iModel.id}`
+          ),
+        children: "Manage versions",
+      }),
+      [navigate]
+    ),
+  };
+};

--- a/packages/app/src/components/SelectionRouter/SelectIModel.tsx
+++ b/packages/app/src/components/SelectionRouter/SelectIModel.tsx
@@ -11,6 +11,7 @@ import { useApiPrefix } from "../../api/useApiPrefix";
 import { useCreateIModelAction } from "../IModelCRUDRouter/useCreateIModelAction";
 import { useDeleteIModelAction } from "../IModelCRUDRouter/useDeleteIModelAction";
 import { useEditIModelAction } from "../IModelCRUDRouter/useEditIModelAction";
+import { useManageVersionsIModelAction } from "../ManageVersionsRouter/useManageVersionsIModelAction";
 import {
   SynchronizationCardContext,
   useSynchronizationCards,
@@ -22,7 +23,13 @@ import { SelectIModelTitle } from "./SelectIModelTitle";
 
 type IModelRouteProps = RouteComponentProps<
   IModelGridProps & {
-    hideActions?: ("view" | "synchronize" | "edit" | "delete")[];
+    hideActions?: (
+      | "view"
+      | "synchronize"
+      | "edit"
+      | "delete"
+      | "manage-versions"
+    )[];
     email?: string;
   }
 >;
@@ -39,6 +46,7 @@ export const SelectIModel = ({
   });
   const { createIconButton } = useCreateIModelAction({ navigate });
   const { synchronizeAction } = useSynchronizeIModelAction();
+  const { manageVersionsAction } = useManageVersionsIModelAction();
   const { editAction } = useEditIModelAction({ navigate });
   const { viewAction } = useViewIModelAction();
   const serverEnvironmentPrefix = useApiPrefix();
@@ -59,6 +67,7 @@ export const SelectIModel = ({
             iModelActions={[
               viewAction,
               editAction,
+              manageVersionsAction,
               synchronizeAction,
               deleteAction,
             ].filter((action) => !hideActions?.includes(action.key as any))}

--- a/packages/app/src/components/SelectionRouter/SelectProject.scss
+++ b/packages/app/src/components/SelectionRouter/SelectProject.scss
@@ -25,7 +25,7 @@
   }
 }
 
-.grid-holding-tabs {
+ul.grid-holding-tabs {
   padding-left: calc(var(--responsive-grid-margin, 64px) - 3px);
 }
 

--- a/packages/app/src/components/SelectionRouter/SelectProject.tsx
+++ b/packages/app/src/components/SelectionRouter/SelectProject.tsx
@@ -50,15 +50,15 @@ export const SelectProject = ({
         labels={[
           <span className={"tab-with-icon"} key="favorite">
             <SvgStarHollow />
-            <p>Favorite projects</p>
+            <span>Favorite projects</span>
           </span>,
           <span className={"tab-with-icon"} key={"recents"}>
             <SvgCalendar />
-            <p>Recent projects</p>
+            <span>Recent projects</span>
           </span>,
           <span className={"tab-with-icon"} key={"all"}>
             <SvgList />
-            <p>My projects</p>
+            <span>My projects</span>
           </span>,
         ]}
         onTabSelected={setProjectType}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,7 +1742,7 @@
   resolved "https://registry.yarnpkg.com/@itwin/itwinui-icons-react/-/itwinui-icons-react-0.1.0.tgz#812bf14c090d7c5a412e9a678781b5a793966ca9"
   integrity sha512-zD11tk6ze8ObJD30l5TOSjQq7giNOwqqLNSqATWSjyiuYnnNlxm80ApKXFfzo+j3hnLg4mQvwhzDPyyMIYzHEw==
 
-"@itwin/itwinui-icons-react@^1.1.1", "@itwin/itwinui-icons-react@^1.1.2":
+"@itwin/itwinui-icons-react@^1.1.1", "@itwin/itwinui-icons-react@^1.1.2", "@itwin/itwinui-icons-react@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@itwin/itwinui-icons-react/-/itwinui-icons-react-1.2.0.tgz#82c6f6896639990c31ee806ee2af6a9ed23856fd"
   integrity sha512-yeBIJPWli/iLKaTLmhsd7ZOn9bMRouN3dGHggJjBjAsgJNNtahbfB/NfOS17DcN6Ejt4Z70VAzMdpwzJ/34CKA==
@@ -1779,6 +1779,16 @@
     classnames "^2.2.6"
     react-table "^7.1.0"
     react-transition-group "^4.1.1"
+
+"@itwin/manage-versions-react@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@itwin/manage-versions-react/-/manage-versions-react-0.5.0.tgz#d517f110112db8524957f94a4d0f769f512e6844"
+  integrity sha512-EwToBiZOs5EuiNgAaBQYPkLFGCrqG3wCIYii73E6t8cLFJ+lpFJt6PGbwrPvdQ8c3QFNXCsnN2FzRKi3SxZmrg==
+  dependencies:
+    "@itwin/itwinui-css" "^0.9.0"
+    "@itwin/itwinui-icons-react" "^1.2.0"
+    "@itwin/itwinui-react" "^1.6.0"
+    classnames "^2.2.6"
 
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"


### PR DESCRIPTION
# Manage Versions !!! 🎉 

Initial surfacing of version management, can be reached by the thrid side nav button (a flag), or by the iModel tile context menu. This pretty much just highlight that there is no way in this application to select a Named Version to view 😉.  We might want to add some entry point in the Synchronize view, for example.

There is currently no way of going directly to the "changes" tab of the Manage Versions component, I already asked @bentleyvk to add some props so we can control that. With such an upgrade, we could add `/manage-versions/project/:projectId/imodel/:iModelId/changes` path (or `?changes` to be consistent with project selection?) and have a direct access to the changes page.

## Side dishes

Changed the project selection tabs to have the default height by changing the `<p>` for a `<span>` (no automatic top/bottom margin by the browser). Uses less spaces and makes it similar to manage versions tabs.

## Known issues

### Synch in QA have issues

At the time of writing, there is something wrong with Synchronization in QA, so when moving through selection, we might get skeleton never finishing, but that is not related to this PR, (however, it shows that what we have so far is a bit too hoping for the happy path, and we might want to look into those types of error, so at least we are not stuck with the skeleton when there is a failure to load. 😉 😉 @aruniverse )

### Manage Version styling is heavily dependent on "private" structure

Manage Versions component is not currently supporting "careless" restlying (well, because nobody needed that 😄). I styled it so it looks pretty much like the project selection, so I added the borders, the line on the top and some other stuff, while most of it is CSS, it relies on the CURRENT structure of the Manage Versions, which is an implementation details. I'll see with @bentleyvk if we can give more options of assigning some classnames to different parts of the component so I can be more confident that even if some part change, it may better handle those changes.
