### PR TITLE
Fix scrollbars not showing up

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "build": "yarn --cwd packages/app build",
     "start": "yarn --cwd packages/app start",
     "test": "yarn --cwd packages/app test",
+    "optest": "yarn --cwd packages/opTestsApp test",
     "lint": "lint-staged --verbose",
     "prepare": "husky install"
   },

--- a/packages/app/src/App.scss
+++ b/packages/app/src/App.scss
@@ -1,8 +1,0 @@
-/*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
- *--------------------------------------------------------------------------------------------*/
-.viewer-container {
-  height: 100%;
-  overflow: auto;
-}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -4,13 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 import React, { useEffect } from "react";
 
-import "./App.scss";
 import { AuthProvider } from "./components/Auth/AuthProvider";
-import { ConfigProvider } from "./config/ConfigProvider";
 import { LaunchDarklyProvider } from "./components/LaunchDarkly/LaunchDarklyProvider";
+import { MainApp } from "./components/MainApp";
+import { ConfigProvider } from "./config/ConfigProvider";
 import history from "./services/router/history";
 import { ai } from "./services/telemetry";
-import { MainApp } from "./components/MainApp";
 
 const App: React.FC = () => {
   useEffect(() => {

--- a/packages/app/src/components/IModelCRUDRouter/IModelCRUDRouter.tsx
+++ b/packages/app/src/components/IModelCRUDRouter/IModelCRUDRouter.tsx
@@ -14,7 +14,7 @@ interface IModelCRUDRouterProps extends RouteComponentProps {
 
 export const IModelCRUDRouter = ({ accessToken }: IModelCRUDRouterProps) => {
   return (
-    <Router className={"router"}>
+    <Router className={"full-height-container"}>
       <IModelCreate
         accessToken={accessToken}
         path="project/:projectId/create-imodel"

--- a/packages/app/src/components/MainLayout/MainContainer.scss
+++ b/packages/app/src/components/MainLayout/MainContainer.scss
@@ -23,6 +23,7 @@
 }
 
 .full-page-content {
+  position: relative;
   display: grid;
   height: 100%;
   overflow: auto;

--- a/packages/app/src/components/MainRouter.tsx
+++ b/packages/app/src/components/MainRouter.tsx
@@ -21,7 +21,7 @@ export const MainRouter = () => {
   }, [accessToken, userInfo]);
 
   return (
-    <Router className={"router"}>
+    <Router className={"full-height-container"}>
       <ViewRouter accessToken={accessTokenStr} path="view/*" email={email} />
       <SynchronizationRouter
         path="synchronize/*"

--- a/packages/app/src/components/ManageVersionsRouter/ManageVersionsRouter.tsx
+++ b/packages/app/src/components/ManageVersionsRouter/ManageVersionsRouter.tsx
@@ -18,7 +18,7 @@ export const ManageVersionsRouter = ({
   email,
 }: ManageVersionsRouterProps) => {
   return (
-    <Router className="router">
+    <Router className="full-height-container">
       <SelectionRouter
         accessToken={accessToken}
         email={email}

--- a/packages/app/src/components/SelectionRouter/SelectIModel.tsx
+++ b/packages/app/src/components/SelectionRouter/SelectIModel.tsx
@@ -9,11 +9,11 @@ import { RouteComponentProps } from "@reach/router";
 import React from "react";
 
 import { useApiPrefix } from "../../api/useApiPrefix";
-import { useDemoFlags } from "../LaunchDarkly/LaunchDarklyProvider";
 import { ai, trackEvent } from "../../services/telemetry";
 import { useCreateIModelAction } from "../IModelCRUDRouter/useCreateIModelAction";
 import { useDeleteIModelAction } from "../IModelCRUDRouter/useDeleteIModelAction";
 import { useEditIModelAction } from "../IModelCRUDRouter/useEditIModelAction";
+import { useDemoFlags } from "../LaunchDarkly/LaunchDarklyProvider";
 import { useManageVersionsIModelAction } from "../ManageVersionsRouter/useManageVersionsIModelAction";
 import {
   SynchronizationCardContext,
@@ -96,4 +96,9 @@ const SelectIModel = ({
   );
 };
 
-export default withAITracking(ai.reactPlugin, SelectIModel, "SelectIModel");
+export default withAITracking(
+  ai.reactPlugin,
+  SelectIModel,
+  "SelectIModel",
+  "full-height-container"
+);

--- a/packages/app/src/components/SelectionRouter/SelectProject.tsx
+++ b/packages/app/src/components/SelectionRouter/SelectProject.tsx
@@ -88,4 +88,9 @@ const SelectProject = ({
   );
 };
 
-export default withAITracking(ai.reactPlugin, SelectProject, "SelectProject");
+export default withAITracking(
+  ai.reactPlugin,
+  SelectProject,
+  "SelectProject",
+  "full-height-container"
+);

--- a/packages/app/src/components/SelectionRouter/SelectionRouter.tsx
+++ b/packages/app/src/components/SelectionRouter/SelectionRouter.tsx
@@ -23,7 +23,7 @@ export const SelectionRouter = ({
   hideIModelActions,
 }: SelectionRouterProps) => {
   return (
-    <Router className={"router"}>
+    <Router className={"full-height-container"}>
       <SelectProject accessToken={accessToken} path="/" />
       <Redirect from={"project"} to={"../"} noThrow={true} />
       <SelectIModel

--- a/packages/app/src/components/SynchronizationRouter/SynchronizationRouter.tsx
+++ b/packages/app/src/components/SynchronizationRouter/SynchronizationRouter.tsx
@@ -18,7 +18,7 @@ export const SynchronizationRouter = ({
   email,
 }: SynchronizationRouterProps) => {
   return (
-    <Router className="router">
+    <Router className="full-height-container">
       <SelectionRouter
         accessToken={accessToken}
         email={email}

--- a/packages/app/src/components/ViewRouter/ViewRouter.tsx
+++ b/packages/app/src/components/ViewRouter/ViewRouter.tsx
@@ -6,8 +6,8 @@ import { Viewer } from "@itwin/web-viewer-react";
 import { RouteComponentProps, Router } from "@reach/router";
 import React from "react";
 
-import AuthClient from "../../services/auth/AuthClient";
 import { useConfig } from "../../config/ConfigProvider";
+import AuthClient from "../../services/auth/AuthClient";
 import { SelectionRouter } from "../SelectionRouter/SelectionRouter";
 
 const useThemeWatcher = () => {
@@ -60,7 +60,7 @@ interface ViewRouterProps extends RouteComponentProps {
 
 export const ViewRouter = ({ accessToken, email }: ViewRouterProps) => {
   return (
-    <Router className="viewer-container router">
+    <Router className="full-height-container">
       <SelectionRouter
         accessToken={accessToken}
         email={email}

--- a/packages/app/src/index.scss
+++ b/packages/app/src/index.scss
@@ -21,7 +21,7 @@ code {
     monospace;
 }
 
-.router {
+.full-height-container {
   overflow: hidden;
   height: 100%;
 }


### PR DESCRIPTION
App insights HOC adds a div at its core and we must set a 100% height on this div so scrollbars shows up correctly.

Refactored `viewer-container` and `router` classes to use `full-height-container` so it can be used safely everywhere we need it.

Added a `position: relative;` to `.full-page-content` so non ideal states are properly centered in the view.

Added a `yarn optest` to launch the operational tests from the root... Just because I like it that way.