### PR TITLE
Fixed flickering dot menu bug

### DIFF
--- a/packages/app/src/components/SelectionRouter/SelectIModel.scss
+++ b/packages/app/src/components/SelectionRouter/SelectIModel.scss
@@ -2,6 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+@import "@itwin/itwinui-css/scss/variables";
+
 .title-section {
   margin: 10px calc(var(--responsive-grid-margin, 64px) - 3px);
 }
@@ -19,7 +21,7 @@
     > .iui-metadata {
       position: absolute;
       bottom: 5px;
-      width: 264px;
+      width: calc(100% - (#{$iui-sm} * 2));
     }
   }
 


### PR DESCRIPTION
Essentially what would happen since the meta-data thing wasn't sized correctly is that the little three dot menu button that would appear when hovering over the imodel component would flicker when you hovered over the portion of the meta-data div that went outside of the component. All I had to do to fix this was change the sizing so it had the correct width.
Before: 
![image](https://user-images.githubusercontent.com/48142512/127380939-081e17ac-b8b8-4ad4-a636-515b69f81e64.png)
After:
![image](https://user-images.githubusercontent.com/48142512/127381045-5aeed77c-96d7-4dc5-8751-cf299f578398.png)
