### PR TITLE
Added if statement to throw error if file size is 0

### DIFF
--- a/packages/app/src/components/SynchronizationRouter/useSynchronizeFileUploader.ts
+++ b/packages/app/src/components/SynchronizationRouter/useSynchronizeFileUploader.ts
@@ -58,6 +58,9 @@ export const useSynchronizeFileUploader = ({
             "This file type is not supported, current file support are .dgn, .rvt, .nwd and .ifc"
           );
         }
+        if (target.size === 0) {
+          throw new Error("Empty file will not be uploaded");
+        }
 
         let storageFileIdToUpdate: string | undefined;
 


### PR DESCRIPTION
When an empty file was uploaded before, the file would get stuck at the file upload section.
![image](https://user-images.githubusercontent.com/48142512/127504958-04542777-3f85-4be4-9139-59fa182f738d.png)
Now, instead of trying to upload the file, we check to see if the file size is zero and throw an error if it is.
![image](https://user-images.githubusercontent.com/48142512/127505438-bfc09e26-f67a-4c13-9c0c-fbce5d02e53a.png)
