### PR TITLE
Allow "my project" search

### DIFF
--- a/packages/app/src/routers/SelectionRouter/SelectIModel.scss
+++ b/packages/app/src/routers/SelectionRouter/SelectIModel.scss
@@ -6,39 +6,41 @@
  *--------------------------------------------------------------------------------------------*/
 @import "@itwin/itwinui-css/scss/variables";
 
-.title-section {
-  margin: 10px calc(var(--responsive-grid-margin, 64px) - 3px);
-}
-
-.tile-with-status.iui-tile {
-  position: relative;
-
-  &.hollow-shell * {
-    pointer-events: none;
+.select-imodel {
+  .title-section {
+    margin: 10px calc(var(--responsive-grid-margin, 64px) - 3px);
   }
 
-  > .iui-content {
-    position: unset;
+  .tile-with-status.iui-tile {
+    position: relative;
 
-    > .iui-metadata {
-      position: absolute;
-      bottom: 5px;
-      width: calc(100% - (#{$iui-sm} * 2));
+    &.hollow-shell * {
+      pointer-events: none;
     }
-  }
 
-  .tile-status {
-    border-top: 1px solid gray;
-    margin-bottom: -12px;
-    margin-left: -12px;
-    margin-right: -12px;
-    padding: 12px;
-    box-sizing: border-box;
+    > .iui-content {
+      position: unset;
 
-    .iui-text-block {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+      > .iui-metadata {
+        position: absolute;
+        bottom: 5px;
+        width: calc(100% - (#{$iui-sm} * 2));
+      }
+    }
+
+    .tile-status {
+      border-top: 1px solid gray;
+      margin-bottom: -12px;
+      margin-left: -12px;
+      margin-right: -12px;
+      padding: 12px;
+      box-sizing: border-box;
+
+      .iui-text-block {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
   }
 }

--- a/packages/app/src/routers/SelectionRouter/SelectIModel.tsx
+++ b/packages/app/src/routers/SelectionRouter/SelectIModel.tsx
@@ -87,7 +87,7 @@ const SelectIModel = ({
   );
 
   return (
-    <div className="scrolling-tab-container">
+    <div className="scrolling-tab-container select-imodel">
       <div className={"title-section"}>
         <SelectIModelTitle accessToken={accessToken} projectId={projectId} />
         <ButtonGroup>{createIconButton}</ButtonGroup>

--- a/packages/app/src/routers/SelectionRouter/SelectProject.scss
+++ b/packages/app/src/routers/SelectionRouter/SelectProject.scss
@@ -6,8 +6,36 @@
  *--------------------------------------------------------------------------------------------*/
 @import "@itwin/itwinui-css/scss/variables";
 
-.title-section {
-  margin: 10px calc(var(--responsive-grid-margin, 64px) - 3px);
+.select-project {
+  .title-section {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 16px;
+    margin: 10px calc(var(--responsive-grid-margin, 64px) - 3px);
+    justify-content: space-between;
+    flex-wrap: wrap-reverse;
+
+    .inline-input-with-button {
+      display: flex;
+      flex-direction: row;
+
+      .iui-input-container.iui-inline > .iui-input:last-child {
+        min-width: 300px;
+        padding-right: 61px;
+      }
+
+      .iui-button {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+        margin-left: -50px;
+      }
+    }
+
+    .iui-input-container.iui-inline {
+      margin: 0;
+    }
+  }
 }
 
 .scrolling-tab-container {


### PR DESCRIPTION
# Project Search

This is adding a search box in the right of the toolbar when "My projects" tab is selected. (Its is only in this tab as it searches through ALL the projects on the server, not merely filtering what is displayed in the favorites/recents)

I did not add "auto search" as the calls are limited, I only trigger the search on "Enter", "Escape" or by clicking on the icon.

We can adjust afterwards, but I suggest that as the initial short term search option.

![image](https://user-images.githubusercontent.com/1904889/128228089-9930137e-f2d8-4cf5-8f02-425055dd70ef.png)
