### PR TITLE
Always refresh data before Edits

### DIFF
--- a/packages/app/src/api/useApiData.ts
+++ b/packages/app/src/api/useApiData.ts
@@ -94,9 +94,9 @@ export const useApiData: <T>(
           })
           .then((result) => {
             if (prefixedUrl) {
-              const FIVE_SEC_IN_MILLISECONDS = 5 * 1000;
+              const FIVE_MIN_IN_MILLISECONDS = 5 * 60 * 1000;
               localCache[prefixedUrl] = {
-                exp: Date.now() + FIVE_SEC_IN_MILLISECONDS,
+                exp: Date.now() + FIVE_MIN_IN_MILLISECONDS,
                 data: result,
               };
             }

--- a/packages/app/src/routers/CRUDRouter/IModelEdit.tsx
+++ b/packages/app/src/routers/CRUDRouter/IModelEdit.tsx
@@ -39,12 +39,17 @@ const useUpdateIModelLoadingStyler = (loading: boolean) => {
 export const IModelEdit = ({ accessToken, iModelId = "" }: EditProps) => {
   const {
     results: { iModel },
+    refreshData,
   } = useApiData<GetIModelResult>({
     accessToken,
     url: `https://api.bentley.com/imodels/${iModelId}`,
   });
   const navigate = useNavigate();
   const goBack = () => navigate?.(-1);
+  const refreshAndGoBack = React.useCallback(async () => {
+    await refreshData();
+    navigate?.(-1);
+  }, [refreshData, navigate]);
   const { ref } = useUpdateIModelLoadingStyler(!iModel);
   const serverEnvironmentPrefix = useApiPrefix();
   return (
@@ -58,7 +63,7 @@ export const IModelEdit = ({ accessToken, iModelId = "" }: EditProps) => {
           description: iModel?.description ?? "",
         }}
         onClose={goBack}
-        onSuccess={goBack}
+        onSuccess={refreshAndGoBack}
         apiOverrides={{ serverEnvironmentPrefix }}
       />
     </div>

--- a/packages/app/src/routers/CRUDRouter/ProjectEdit.tsx
+++ b/packages/app/src/routers/CRUDRouter/ProjectEdit.tsx
@@ -39,12 +39,18 @@ const useUpdateProjectLoadingStyler = (loading: boolean) => {
 export const ProjectEdit = ({ accessToken, projectId = "" }: EditProps) => {
   const {
     results: { project },
+    refreshData,
   } = useApiData<GetIModelResult>({
     accessToken,
     url: `https://api.bentley.com/projects/${projectId}`,
   });
   const navigate = useNavigate();
   const goBack = () => navigate?.(-1);
+  const refreshAndGoBack = React.useCallback(async () => {
+    await refreshData();
+    navigate?.(-1);
+  }, [refreshData, navigate]);
+
   const { ref } = useUpdateProjectLoadingStyler(!project);
   const serverEnvironmentPrefix = useApiPrefix();
   return (
@@ -58,7 +64,7 @@ export const ProjectEdit = ({ accessToken, projectId = "" }: EditProps) => {
           projectNumber: project?.projectNumber ?? "",
         }}
         onClose={goBack}
-        onSuccess={goBack}
+        onSuccess={refreshAndGoBack}
         apiOverrides={{ serverEnvironmentPrefix }}
       />
     </div>


### PR DESCRIPTION
edit-imodel and edit-project fetches the data using useApiData, which have an automatic 5 min cache so the same request does not go to the server over and over again, however, this causes problems with edits as if you edit and go straight back to it, it will not requery and show the old data.

This forces the requery of the data after the update completes, refreshing the cache with the up to date value.