### PR TITLE
Simple pascalCase to sentence statuses

### DIFF
--- a/packages/app/src/routers/SynchronizationRouter/components/ConnectionsTable.tsx
+++ b/packages/app/src/routers/SynchronizationRouter/components/ConnectionsTable.tsx
@@ -20,7 +20,7 @@ import {
 } from "../../../api/synchronization/generated";
 import { SynchronizationClient } from "../../../api/synchronization/synchronizationClient";
 import { useApiPrefix } from "../../../api/useApiPrefix";
-import { CreateTypeFromInterface } from "../../../utils";
+import { CreateTypeFromInterface, pascalCaseToSentence } from "../../../utils";
 import { LastRunContext } from "../Synchronize";
 import { interpretRunInfo } from "../useSynchronizeInfo";
 import "./ConnectionsTable.scss";
@@ -62,7 +62,7 @@ export const ConnectionsTable = ({
                       <div className={"status-cell"}>
                         {run?.state && run.result && runInfo.icon}
                         {runInfo.time}{" "}
-                        {runInfo.status ?? (
+                        {pascalCaseToSentence(runInfo.status?.toString()) ?? (
                           <Body isSkeleton={true}>Fetching...</Body>
                         )}
                       </div>

--- a/packages/app/src/routers/SynchronizationRouter/components/ConnectionsTable.tsx
+++ b/packages/app/src/routers/SynchronizationRouter/components/ConnectionsTable.tsx
@@ -20,7 +20,10 @@ import {
 } from "../../../api/synchronization/generated";
 import { SynchronizationClient } from "../../../api/synchronization/synchronizationClient";
 import { useApiPrefix } from "../../../api/useApiPrefix";
-import { CreateTypeFromInterface, pascalCaseToSentence } from "../../../utils";
+import {
+  CreateTypeFromInterface,
+  pascalCaseToSentenceCase,
+} from "../../../utils";
 import { LastRunContext } from "../Synchronize";
 import { interpretRunInfo } from "../useSynchronizeInfo";
 import "./ConnectionsTable.scss";
@@ -62,9 +65,9 @@ export const ConnectionsTable = ({
                       <div className={"status-cell"}>
                         {run?.state && run.result && runInfo.icon}
                         {runInfo.time}{" "}
-                        {pascalCaseToSentence(runInfo.status?.toString()) ?? (
-                          <Body isSkeleton={true}>Fetching...</Body>
-                        )}
+                        {pascalCaseToSentenceCase(
+                          runInfo.status?.toString()
+                        ) ?? <Body isSkeleton={true}>Fetching...</Body>}
                       </div>
                     </SkeletonCell>
                   );

--- a/packages/app/src/routers/SynchronizationRouter/components/SourcesTable.tsx
+++ b/packages/app/src/routers/SynchronizationRouter/components/SourcesTable.tsx
@@ -9,7 +9,7 @@ import React from "react";
 
 import { StorageFile } from "../../../api/synchronization/generated";
 import { SynchronizationClient } from "../../../api/synchronization/synchronizationClient";
-import { CreateTypeFromInterface } from "../../../utils";
+import { CreateTypeFromInterface, pascalCaseToSentence } from "../../../utils";
 import { LastRunContext } from "../Synchronize";
 import { BridgeIcon } from "./BridgeIcon";
 import { SkeletonCell } from "./SkeletonCell";
@@ -58,7 +58,7 @@ export const SourcesTable = ({ sources }: SourcesTableProps) => {
                   lastRunResults,
                   props.value
                 );
-                display = task?.state ?? "";
+                display = pascalCaseToSentence(task?.state) ?? "";
               }
               if (!display && !props.row.original.lastKnownFileName) {
                 display = "Connection must be run after uploading the file";

--- a/packages/app/src/routers/SynchronizationRouter/components/SourcesTable.tsx
+++ b/packages/app/src/routers/SynchronizationRouter/components/SourcesTable.tsx
@@ -9,7 +9,10 @@ import React from "react";
 
 import { StorageFile } from "../../../api/synchronization/generated";
 import { SynchronizationClient } from "../../../api/synchronization/synchronizationClient";
-import { CreateTypeFromInterface, pascalCaseToSentence } from "../../../utils";
+import {
+  CreateTypeFromInterface,
+  pascalCaseToSentenceCase,
+} from "../../../utils";
 import { LastRunContext } from "../Synchronize";
 import { BridgeIcon } from "./BridgeIcon";
 import { SkeletonCell } from "./SkeletonCell";
@@ -58,7 +61,7 @@ export const SourcesTable = ({ sources }: SourcesTableProps) => {
                   lastRunResults,
                   props.value
                 );
-                display = pascalCaseToSentence(task?.state) ?? "";
+                display = pascalCaseToSentenceCase(task?.state) ?? "";
               }
               if (!display && !props.row.original.lastKnownFileName) {
                 display = "Connection must be run after uploading the file";

--- a/packages/app/src/routers/SynchronizationRouter/useSynchronizationCards.tsx
+++ b/packages/app/src/routers/SynchronizationRouter/useSynchronizationCards.tsx
@@ -23,6 +23,7 @@ import {
 } from "../../api/synchronization/generated";
 import { SynchronizationClient } from "../../api/synchronization/synchronizationClient";
 import { useApiPrefix } from "../../api/useApiPrefix";
+import { pascalCaseToSentence } from "../../utils";
 import { DetailedStatus } from "./components/DetailedStatus";
 import { TileDropTarget } from "./components/TileDropTarget";
 import { useSynchronizeFileUploader } from "./useSynchronizeFileUploader";
@@ -143,7 +144,9 @@ export const useSynchronizationCards: UseIndividualState = (
         const runInfo = interpretRunInfo(lastRunResults);
         setConnectionStatus(
           <DetailedStatus
-            text={`${runInfo.time} ${runInfo.status}`}
+            text={`${runInfo.time} ${pascalCaseToSentence(
+              runInfo.status?.toString()
+            )}`}
             altIcon={runInfo.icon}
           />
         );

--- a/packages/app/src/routers/SynchronizationRouter/useSynchronizationCards.tsx
+++ b/packages/app/src/routers/SynchronizationRouter/useSynchronizationCards.tsx
@@ -23,7 +23,7 @@ import {
 } from "../../api/synchronization/generated";
 import { SynchronizationClient } from "../../api/synchronization/synchronizationClient";
 import { useApiPrefix } from "../../api/useApiPrefix";
-import { pascalCaseToSentence } from "../../utils";
+import { pascalCaseToSentenceCase } from "../../utils";
 import { DetailedStatus } from "./components/DetailedStatus";
 import { TileDropTarget } from "./components/TileDropTarget";
 import { useSynchronizeFileUploader } from "./useSynchronizeFileUploader";
@@ -144,7 +144,7 @@ export const useSynchronizationCards: UseIndividualState = (
         const runInfo = interpretRunInfo(lastRunResults);
         setConnectionStatus(
           <DetailedStatus
-            text={`${runInfo.time} ${pascalCaseToSentence(
+            text={`${runInfo.time} ${pascalCaseToSentenceCase(
               runInfo.status?.toString()
             )}`}
             altIcon={runInfo.icon}

--- a/packages/app/src/utils.ts
+++ b/packages/app/src/utils.ts
@@ -22,7 +22,7 @@ export type CreateTypeFromInterface<Interface> = {
 /**
  * Convert a "PascalCase" value to its corresponding "Pascal case." string
  * @param text PascalCase string
- * @returns Pascal Case string
+ * @returns Sentence case string
  */
 export const pascalCaseToSentenceCase = (text?: string) => {
   const str = text

--- a/packages/app/src/utils.ts
+++ b/packages/app/src/utils.ts
@@ -20,9 +20,14 @@ export type CreateTypeFromInterface<Interface> = {
 };
 
 /**
- * Convert a "PascalCase" value to its corresponding "Pascal Case" string
+ * Convert a "PascalCase" value to its corresponding "Pascal case." string
  * @param text PascalCase string
  * @returns Pascal Case string
  */
-export const pascalCaseToSentence = (text?: string) =>
-  text?.replace(/([A-Z])/g, " $1").trim();
+export const pascalCaseToSentenceCase = (text?: string) => {
+  const str = text
+    ?.replace(/([A-Z])/g, " $1")
+    .trim()
+    .toLowerCase();
+  return str ? str.charAt(0).toUpperCase() + str.slice(1) : undefined;
+};

--- a/packages/app/src/utils.ts
+++ b/packages/app/src/utils.ts
@@ -18,3 +18,11 @@ export const spreadIf: <T>(addIfTrue: T | Falsy) => [T] | [] = (addIfTrue) =>
 export type CreateTypeFromInterface<Interface> = {
   [Property in keyof Interface]: Interface[Property];
 };
+
+/**
+ * Convert a "PascalCase" value to its corresponding "Pascal Case" string
+ * @param text PascalCase string
+ * @returns Pascal Case string
+ */
+export const pascalCaseToSentence = (text?: string) =>
+  text?.replace(/([A-Z])/g, " $1").trim();


### PR DESCRIPTION
Completely out of the blue, I think it makes it looks better.

All statuses we display are now "sentences" instead of a program code:

![image](https://user-images.githubusercontent.com/1904889/128560524-67a736f6-4412-4040-b957-34e71306e224.png)
