### PR TITLE
Auth: Add silent renew

### DIFF
--- a/packages/app/src/components/Auth/AuthProvider.tsx
+++ b/packages/app/src/components/Auth/AuthProvider.tsx
@@ -59,7 +59,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         // attempt silent signin
         await AuthClient.signInSilent();
       } catch (error) {
-        // swallow the error. User can click the button to sign in
+        // if silent sign in fails, have user manually sign in
         await AuthClient.signIn();
       } finally {
         setIsAuthenticated(AuthClient.client?.isAuthorized ?? false);

--- a/packages/app/src/components/Auth/AuthProvider.tsx
+++ b/packages/app/src/components/Auth/AuthProvider.tsx
@@ -5,7 +5,7 @@
  * This code is for demonstration purposes and should not be considered production ready.
  *--------------------------------------------------------------------------------------------*/
 import { AccessToken, UserInfo } from "@bentley/itwin-client";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useConfig } from "../../config/ConfigProvider";
 import AuthClient from "../../services/auth/AuthClient";
@@ -16,6 +16,7 @@ export interface AuthContextValue {
   isAuthorized: boolean;
   accessToken?: AccessToken;
   userInfo?: UserInfo;
+  signOut: () => void;
 }
 
 export interface AuthProviderProps {
@@ -25,6 +26,9 @@ export interface AuthProviderProps {
 const AuthContext = React.createContext<AuthContextValue>({
   isAuthenticated: false,
   isAuthorized: false,
+  signOut: async () => {
+    await AuthClient.signOut();
+  },
 });
 
 export const AuthProvider = ({ children }: AuthProviderProps) => {
@@ -82,6 +86,10 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     return false;
   }, [auth, userInfo]);
 
+  const signOut = useCallback(async () => {
+    await AuthClient.signOut();
+  }, []);
+
   return (
     <AuthContext.Provider
       value={{
@@ -89,6 +97,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         isAuthorized,
         accessToken,
         userInfo,
+        signOut,
       }}
     >
       {children}

--- a/packages/app/src/components/Auth/AuthProvider.tsx
+++ b/packages/app/src/components/Auth/AuthProvider.tsx
@@ -78,12 +78,15 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   }, [auth]);
 
   const isAuthorized = useMemo(() => {
-    if (auth?.whitelistedIds && userInfo?.organization?.id) {
-      const whitelist = auth.whitelistedIds.split(" ");
-      const orgId = userInfo.organization?.id;
-      return whitelist.includes(orgId);
+    if (auth?.whitelistedIds) {
+      if (userInfo?.organization?.id) {
+        const whitelist = auth.whitelistedIds.split(" ");
+        const orgId = userInfo.organization?.id;
+        return whitelist.includes(orgId);
+      }
+      return false;
     }
-    return false;
+    return true;
   }, [auth, userInfo]);
 
   const signOut = useCallback(async () => {

--- a/packages/app/src/components/Header/Header.tsx
+++ b/packages/app/src/components/Header/Header.tsx
@@ -4,6 +4,7 @@
  *
  * This code is for demonstration purposes and should not be considered production ready.
  *--------------------------------------------------------------------------------------------*/
+import { AccessToken } from "@bentley/itwin-client";
 import { SvgImodelHollow, SvgMoon, SvgSun } from "@itwin/itwinui-icons-react";
 import {
   Header as IuiHeader,
@@ -18,19 +19,27 @@ import React from "react";
 
 import AuthClient from "../../services/auth/AuthClient";
 import { spreadIf } from "../../utils";
-import { useAuth } from "../Auth/AuthProvider";
 import { useCommonPathPattern } from "../MainLayout/useCommonPathPattern";
 import { HeaderUserIcon } from "./HeaderUserIcon";
 import { IModelHeaderButton } from "./IModelHeaderButton";
 import { ProjectHeaderButton } from "./ProjectHeaderButton";
 
-export const Header = () => (
+interface HeaderProps {
+  isAuthenticated: boolean;
+  accessToken?: AccessToken;
+}
+
+export const Header = (props: HeaderProps) => (
   <Router>
-    <RoutedHeader default={true} />
+    <RoutedHeader {...props} default={true} />
   </Router>
 );
 
-const RoutedHeader = ({ navigate }: RouteComponentProps) => {
+const RoutedHeader = ({
+  isAuthenticated,
+  accessToken,
+  navigate,
+}: RouteComponentProps<HeaderProps>) => {
   const [theme, setTheme] = React.useState<ThemeType>(
     (localStorage.getItem("THEME") as ThemeType) ?? "light"
   );
@@ -43,11 +52,9 @@ const RoutedHeader = ({ navigate }: RouteComponentProps) => {
   const { section, projectId, iModelId } = useCommonPathPattern();
   const slimMatch = !!useMatch("/view/project/:projectId/imodel/:iModelId");
 
-  const { accessToken, isAuthenticated } = useAuth();
-
-  const handleLogout = async () => {
+  const handleLogout = React.useCallback(async () => {
     await AuthClient.signOut();
-  };
+  }, []);
 
   return (
     <IuiHeader

--- a/packages/app/src/components/Header/Header.tsx
+++ b/packages/app/src/components/Header/Header.tsx
@@ -17,7 +17,6 @@ import {
 import { RouteComponentProps, Router, useMatch } from "@reach/router";
 import React from "react";
 
-import AuthClient from "../../services/auth/AuthClient";
 import { spreadIf } from "../../utils";
 import { useCommonPathPattern } from "../MainLayout/useCommonPathPattern";
 import { HeaderUserIcon } from "./HeaderUserIcon";
@@ -27,6 +26,7 @@ import { ProjectHeaderButton } from "./ProjectHeaderButton";
 interface HeaderProps {
   isAuthenticated: boolean;
   accessToken?: AccessToken;
+  handleLogout: () => void;
 }
 
 export const Header = (props: HeaderProps) => (
@@ -38,6 +38,7 @@ export const Header = (props: HeaderProps) => (
 const RoutedHeader = ({
   isAuthenticated,
   accessToken,
+  handleLogout,
   navigate,
 }: RouteComponentProps<HeaderProps>) => {
   const [theme, setTheme] = React.useState<ThemeType>(
@@ -51,10 +52,6 @@ const RoutedHeader = ({
 
   const { section, projectId, iModelId } = useCommonPathPattern();
   const slimMatch = !!useMatch("/view/project/:projectId/imodel/:iModelId");
-
-  const handleLogout = React.useCallback(async () => {
-    await AuthClient.signOut();
-  }, []);
 
   return (
     <IuiHeader

--- a/packages/app/src/components/MainApp.tsx
+++ b/packages/app/src/components/MainApp.tsx
@@ -26,7 +26,8 @@ export const MainApp = () => {
 
   const onLoginClick = async () => {
     setIsLoggingIn(true);
-    await AuthClient.signIn();
+    // await AuthClient.signIn();
+    await AuthClient.signInSilent();
   };
 
   const onLogoutClick = async () => {

--- a/packages/app/src/components/MainApp.tsx
+++ b/packages/app/src/components/MainApp.tsx
@@ -14,12 +14,21 @@ import MainContainer from "./MainLayout/MainContainer";
 import { Sidebar } from "./MainLayout/Sidebar";
 
 export const MainApp = () => {
-  const { isAuthenticated, isAuthorized } = useAuth();
+  const { isAuthenticated, isAuthorized, accessToken } = useAuth();
 
   return (
-    <MainContainer header={<Header />} sidebar={<Sidebar />}>
+    <MainContainer
+      header={
+        <Header isAuthenticated={isAuthenticated} accessToken={accessToken} />
+      }
+      sidebar={<Sidebar />}
+    >
       {isAuthenticated &&
-        (isAuthorized ? <MainRouter /> : <ErrorPage errorType="401" />)}
+        (isAuthorized ? (
+          <MainRouter accessToken={accessToken} />
+        ) : (
+          <ErrorPage errorType="401" />
+        ))}
     </MainContainer>
   );
 };

--- a/packages/app/src/components/MainApp.tsx
+++ b/packages/app/src/components/MainApp.tsx
@@ -4,56 +4,22 @@
  *
  * This code is for demonstration purposes and should not be considered production ready.
  *--------------------------------------------------------------------------------------------*/
-import { FillCentered } from "@bentley/ui-core";
 import { ErrorPage } from "@itwin/itwinui-react";
-import React, { useState } from "react";
+import React from "react";
 
 import { MainRouter } from "../routers/MainRouter";
-import AuthClient from "../services/auth/AuthClient";
 import { useAuth } from "./Auth/AuthProvider";
 import { Header } from "./Header/Header";
 import MainContainer from "./MainLayout/MainContainer";
 import { Sidebar } from "./MainLayout/Sidebar";
 
 export const MainApp = () => {
-  const [isLoggingIn, setIsLoggingIn] = useState(false);
-  const {
-    accessToken,
-    isAuthenticated,
-    isAuthorized,
-    isAttemptingSilentLogin,
-  } = useAuth();
-
-  const onLoginClick = async () => {
-    setIsLoggingIn(true);
-    // await AuthClient.signIn();
-    await AuthClient.signInSilent();
-  };
-
-  const onLogoutClick = async () => {
-    setIsLoggingIn(false);
-    await AuthClient.signOut();
-  };
+  const { isAuthenticated, isAuthorized } = useAuth();
 
   return (
-    <MainContainer
-      header={
-        <Header
-          handleLogin={onLoginClick}
-          handleLogout={onLogoutClick}
-          loggedIn={isAuthenticated}
-          isLoggingIn={isAttemptingSilentLogin || isLoggingIn}
-          accessTokenObject={accessToken}
-        />
-      }
-      sidebar={<Sidebar />}
-    >
-      {isLoggingIn ? (
-        <FillCentered>{"Logging in...."}</FillCentered>
-      ) : (
-        isAuthenticated &&
-        (isAuthorized ? <MainRouter /> : <ErrorPage errorType="401" />)
-      )}
+    <MainContainer header={<Header />} sidebar={<Sidebar />}>
+      {isAuthenticated &&
+        (isAuthorized ? <MainRouter /> : <ErrorPage errorType="401" />)}
     </MainContainer>
   );
 };

--- a/packages/app/src/components/MainApp.tsx
+++ b/packages/app/src/components/MainApp.tsx
@@ -14,12 +14,16 @@ import MainContainer from "./MainLayout/MainContainer";
 import { Sidebar } from "./MainLayout/Sidebar";
 
 export const MainApp = () => {
-  const { isAuthenticated, isAuthorized, accessToken } = useAuth();
+  const { isAuthenticated, isAuthorized, accessToken, signOut } = useAuth();
 
   return (
     <MainContainer
       header={
-        <Header isAuthenticated={isAuthenticated} accessToken={accessToken} />
+        <Header
+          isAuthenticated={isAuthenticated}
+          accessToken={accessToken}
+          handleLogout={signOut}
+        />
       }
       sidebar={<Sidebar />}
     >

--- a/packages/app/src/routers/MainRouter.tsx
+++ b/packages/app/src/routers/MainRouter.tsx
@@ -4,16 +4,19 @@
  *
  * This code is for demonstration purposes and should not be considered production ready.
  *--------------------------------------------------------------------------------------------*/
+import { AccessToken } from "@bentley/itwin-client";
 import { Redirect, Router } from "@reach/router";
 import React, { useMemo } from "react";
 
-import { useAuth } from "../components/Auth/AuthProvider";
 import { ManageVersionsRouter } from "./ManageVersionsRouter/ManageVersionsRouter";
 import { SynchronizationRouter } from "./SynchronizationRouter/SynchronizationRouter";
 import { ViewRouter } from "./ViewRouter/ViewRouter";
 
-export const MainRouter = () => {
-  const { accessToken } = useAuth();
+interface MainRouterProps {
+  accessToken?: AccessToken;
+}
+
+export const MainRouter = ({ accessToken }: MainRouterProps) => {
   const accessTokenStr = useMemo(() => {
     return accessToken?.toTokenString() ?? "";
   }, [accessToken]);

--- a/packages/app/src/services/auth/AuthClient.ts
+++ b/packages/app/src/services/auth/AuthClient.ts
@@ -31,6 +31,9 @@ class AuthClient {
         responseType: "code",
         authority,
       });
+      this._client.setAdvancedSettings({
+        silent_redirect_uri: `${window.location.origin}/silentauth`,
+      });
     }
     return this._client;
   }

--- a/packages/app/src/services/auth/AuthClient.ts
+++ b/packages/app/src/services/auth/AuthClient.ts
@@ -32,7 +32,7 @@ class AuthClient {
         authority,
       });
       this._client.setAdvancedSettings({
-        silent_redirect_uri: `${window.location.origin}/silentauth`,
+        silent_redirect_uri: redirectUri,
       });
     }
     return this._client;

--- a/packages/opTestsApp/src/helpers/selectors.ts
+++ b/packages/opTestsApp/src/helpers/selectors.ts
@@ -33,14 +33,6 @@ export const OIDC: OIDCSelectors = {
   },
 };
 
-export interface BaseSelectors {
-  signInButton: string;
-}
-
-export const Base: BaseSelectors = {
-  signInButton: "text='Sign In'",
-};
-
 export interface HomeSelectors {
   icon: string;
   Portal: string;

--- a/packages/opTestsApp/src/setupTest.ts
+++ b/packages/opTestsApp/src/setupTest.ts
@@ -8,7 +8,7 @@
 import { Browser, BrowserContext, chromium, Page } from "playwright-chromium";
 
 import { SiteUrl, User, User1 } from "./helpers/config"; // BrowserName
-import { Base, Home, OIDC } from "./helpers/selectors";
+import { Home, OIDC } from "./helpers/selectors";
 import { elementExists, getBrowserPath } from "./helpers/utils";
 
 let context: BrowserContext;
@@ -28,7 +28,6 @@ export const login = async (
 
   try {
     await page.goto(SiteUrl);
-    await page.click(Base.signInButton);
     if (await elementExists(page, OIDC.v2.usernameInput)) {
       await page.fill(OIDC.v2.usernameInput, user.username);
       await page.click(OIDC.v2.nextInput, { delay: 500 });


### PR DESCRIPTION
The UserManager created by core in the [BrowserAuthorizationClient](https://github1s.com/imodeljs/imodeljs/blob/HEAD/clients/frontend-authorization/src/oidc/browser/BrowserAuthorizationClient.ts#L95-L105) doesn't set the silent_redirect_uri by default. So we manually set it ourselves.

Cleanup, and remove the sign-in button from the header, since you should be automatically signed in to demo portal if you have a session else where or have to manually sign in.

If no whitelist is present in your .env then you have full access.
