### PR TITLE
View named versions

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -34,7 +34,7 @@
     "@itwin/itwinui-css": "^0.18.1",
     "@itwin/itwinui-icons-react": "^1.2.0",
     "@itwin/itwinui-react": "^1.12.0",
-    "@itwin/manage-versions-react": "^0.5.0",
+    "@itwin/manage-versions-react": "^0.7.0",
     "@itwin/web-viewer-react": "^1.0.8",
     "@microsoft/applicationinsights-react-js": "^3.1.3",
     "@microsoft/applicationinsights-web": "^2.6.4",

--- a/packages/app/src/components/Header/Header.tsx
+++ b/packages/app/src/components/Header/Header.tsx
@@ -22,6 +22,7 @@ import { useCommonPathPattern } from "../MainLayout/useCommonPathPattern";
 import { HeaderUserIcon } from "./HeaderUserIcon";
 import { IModelHeaderButton } from "./IModelHeaderButton";
 import { ProjectHeaderButton } from "./ProjectHeaderButton";
+import { VersionHeaderButton } from "./VersionHeaderButton";
 
 interface HeaderProps {
   isAuthenticated: boolean;
@@ -51,7 +52,14 @@ const RoutedHeader = ({
   }, [theme]);
 
   const { section, projectId, iModelId } = useCommonPathPattern();
-  const slimMatch = !!useMatch("/view/project/:projectId/imodel/:iModelId");
+  const versionMatch = useMatch(
+    "/:section/project/:projectId/imodel/:iModelId/version/:versionId"
+  );
+
+  const slimMatch = [
+    !!useMatch("/view/project/:projectId/imodel/:iModelId"),
+    !!useMatch("/view/project/:projectId/imodel/:iModelId/version/:versionId"),
+  ].includes(true);
 
   return (
     <IuiHeader
@@ -81,6 +89,18 @@ const RoutedHeader = ({
                   key="iModel"
                   iModelId={iModelId}
                   projectId={projectId}
+                  accessToken={accessToken?.toTokenString()}
+                  section={section}
+                />
+              )
+            ),
+            ...spreadIf(
+              isAuthenticated && iModelId && section === "view" && (
+                <VersionHeaderButton
+                  key="version"
+                  iModelId={iModelId}
+                  projectId={projectId}
+                  versionId={versionMatch?.versionId}
                   accessToken={accessToken?.toTokenString()}
                   section={section}
                 />

--- a/packages/app/src/components/Header/IModelHeaderButton.tsx
+++ b/packages/app/src/components/Header/IModelHeaderButton.tsx
@@ -41,7 +41,7 @@ export const IModelHeaderButton = ({
       description={iModel?.description}
       onClick={() => navigate(`/${section}/project/${projectId}`)}
       className={classNames(!iModel && "iui-skeleton")}
-      isActive={!!iModel?.displayName}
+      isActive={!!iModel?.displayName && section !== "view"}
       startIcon={
         !!iModel?.displayName ? (
           <IModelThumbnail

--- a/packages/app/src/components/Header/VersionHeaderButton.tsx
+++ b/packages/app/src/components/Header/VersionHeaderButton.tsx
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *
+ * This code is for demonstration purposes and should not be considered production ready.
+ *--------------------------------------------------------------------------------------------*/
+import { HeaderButton } from "@itwin/itwinui-react";
+import { useNavigate } from "@reach/router";
+import classNames from "classnames";
+import React from "react";
+
+import { useApiData } from "../../api/useApiData";
+
+interface IdAndDisplay {
+  id: string;
+  displayName?: string;
+}
+
+interface VersionHeaderButtonProps {
+  versionId?: string;
+  accessToken?: string;
+  iModelId?: string;
+  projectId?: string;
+  section?: string;
+}
+export const VersionHeaderButton = ({
+  iModelId,
+  section,
+  projectId,
+  accessToken,
+  versionId,
+}: VersionHeaderButtonProps) => {
+  const navigate = useNavigate();
+  const {
+    results: { namedVersion: fetchedVersion },
+  } = useApiData<{ namedVersion: IdAndDisplay }>({
+    accessToken: versionId ? accessToken : undefined,
+    url: `https://api.bentley.com/imodels/${iModelId}/namedversions/${versionId}`,
+  });
+  const namedVersion = versionId
+    ? fetchedVersion
+    : {
+        displayName: "Latest checkpoint",
+      };
+  return section === "view" ? (
+    <HeaderButton
+      key="namedVersion"
+      name={namedVersion ? namedVersion?.displayName : "Fetching version"}
+      onClick={() =>
+        navigate(`/manage-versions/project/${projectId}/imodel/${iModelId}`)
+      }
+      className={classNames(!namedVersion && "iui-skeleton")}
+      isActive={!!namedVersion?.displayName}
+    />
+  ) : null;
+};

--- a/packages/app/src/components/Header/VersionHeaderButton.tsx
+++ b/packages/app/src/components/Header/VersionHeaderButton.tsx
@@ -4,6 +4,7 @@
  *
  * This code is for demonstration purposes and should not be considered production ready.
  *--------------------------------------------------------------------------------------------*/
+import { SvgFlag } from "@itwin/itwinui-icons-react";
 import { HeaderButton } from "@itwin/itwinui-react";
 import { useNavigate } from "@reach/router";
 import classNames from "classnames";
@@ -51,6 +52,7 @@ export const VersionHeaderButton = ({
       }
       className={classNames(!namedVersion && "iui-skeleton")}
       isActive={!!namedVersion?.displayName}
+      startIcon={<SvgFlag />}
     />
   ) : null;
 };

--- a/packages/app/src/routers/ManageVersionsRouter/ManageVersions.scss
+++ b/packages/app/src/routers/ManageVersionsRouter/ManageVersions.scss
@@ -16,16 +16,21 @@
     height: 100%;
     flex-direction: column;
 
+    .iui-tab-stripe {
+      margin-left: calc(var(--responsive-grid-margin, 64px) - 3px);
+    }
+
     > * {
       padding-left: calc(var(--responsive-grid-margin, 64px) - 3px);
       padding-right: calc(var(--responsive-grid-margin, 64px) - 3px);
     }
 
-    > ul + * {
-      margin-top: -9px;
-      padding-top: 9px;
+    > .iui-table {
+      margin-top: -2px;
+      padding-top: 10px;
+      padding-bottom: 10px;
       overflow: auto;
-      flex-basis: 100%;
+
       @include themed {
         border-top: 2px solid t(iui-color-background-5);
       }

--- a/packages/app/src/routers/ManageVersionsRouter/ManageVersions.tsx
+++ b/packages/app/src/routers/ManageVersionsRouter/ManageVersions.tsx
@@ -4,22 +4,44 @@
  *
  * This code is for demonstration purposes and should not be considered production ready.
  *--------------------------------------------------------------------------------------------*/
-import { ManageVersions as ACRManageVersions } from "@itwin/manage-versions-react";
-import { RouteComponentProps } from "@reach/router";
+import {
+  ManageVersions as ACRManageVersions,
+  ManageVersionsProps,
+} from "@itwin/manage-versions-react";
+import { RouteComponentProps, useLocation, useNavigate } from "@reach/router";
 import React from "react";
 
 import { useApiPrefix } from "../../api/useApiPrefix";
 import "./ManageVersions.scss";
 
+type ManageVersionsTabs = Required<ManageVersionsProps>["currentTab"];
+
+const CHANGE_TAB_SEARCHSTRING = "?changes";
 export interface VersionsProps extends RouteComponentProps {
+  projectId?: string;
   iModelId?: string;
   accessToken: string;
 }
 export const ManageVersions = ({
   iModelId = "",
+  projectId = "",
   accessToken,
+  navigate: localNavigate,
 }: VersionsProps) => {
+  const location = useLocation();
   const serverEnvironmentPrefix = useApiPrefix();
+  const globalNavigate = useNavigate();
+  const [tab, setTab] = React.useState<ManageVersionsTabs>(
+    location.search === CHANGE_TAB_SEARCHSTRING ? 1 : 0
+  );
+  React.useEffect(() => {
+    const search = tab === 1 ? CHANGE_TAB_SEARCHSTRING : "";
+    if (location.search !== search) {
+      void localNavigate?.(`./${search}`, {
+        replace: true,
+      });
+    }
+  }, [location.search, localNavigate, tab]);
 
   return (
     <div className="manage-versions-with-side-and-splitter">
@@ -27,6 +49,13 @@ export const ManageVersions = ({
         accessToken={accessToken}
         imodelId={iModelId}
         apiOverrides={{ serverEnvironmentPrefix }}
+        onViewClick={(version) =>
+          globalNavigate(
+            `/view/project/${projectId}/imodel/${iModelId}/version/${version.id}`
+          )
+        }
+        onTabChange={setTab}
+        currentTab={tab}
       />
     </div>
   );

--- a/packages/app/src/routers/ViewRouter/ViewRouter.tsx
+++ b/packages/app/src/routers/ViewRouter/ViewRouter.tsx
@@ -8,6 +8,7 @@ import { Viewer } from "@itwin/web-viewer-react";
 import { RouteComponentProps, Router } from "@reach/router";
 import React from "react";
 
+import { useApiData } from "../../api/useApiData";
 import { useConfig } from "../../config/ConfigProvider";
 import AuthClient from "../../services/auth/AuthClient";
 import { SelectionRouter } from "../SelectionRouter/SelectionRouter";
@@ -36,8 +37,10 @@ const useThemeWatcher = () => {
   return theme;
 };
 export interface ViewProps extends RouteComponentProps {
+  accessToken?: string;
   projectId?: string;
   iModelId?: string;
+  versionId?: string;
 }
 const View = (props: ViewProps) => {
   (window as any).ITWIN_VIEWER_HOME = window.location.origin;
@@ -45,8 +48,17 @@ const View = (props: ViewProps) => {
   const buddiRegion = config.buddi?.region
     ? parseInt(config.buddi.region)
     : undefined;
+  const {
+    results: { namedVersion: fetchedVersion },
+  } = useApiData<{ namedVersion: { changesetId: string } }>({
+    accessToken: props.versionId ? props.accessToken : undefined,
+    url: `https://api.bentley.com/imodels/${props.iModelId}/namedversions/${props.versionId}`,
+  });
+
+  const changesetId = props.versionId ? fetchedVersion?.changesetId : undefined;
   return (
     <Viewer
+      changeSetId={changesetId}
       contextId={props.projectId ?? ""}
       iModelId={props.iModelId ?? ""}
       authConfig={{ oidcClient: AuthClient.client }}
@@ -70,6 +82,7 @@ export const ViewRouter = ({ accessToken }: ViewRouterProps) => {
         hideIModelActions={["view"]}
       />
       <View path="project/:projectId/imodel/:iModelId" />
+      <View path="project/:projectId/imodel/:iModelId/version/:versionId" />
     </Router>
   );
 };

--- a/packages/app/src/routers/ViewRouter/ViewRouter.tsx
+++ b/packages/app/src/routers/ViewRouter/ViewRouter.tsx
@@ -50,23 +50,24 @@ const View = (props: ViewProps) => {
     : undefined;
   const {
     results: { namedVersion: fetchedVersion },
+    state,
   } = useApiData<{ namedVersion: { changesetId: string } }>({
     accessToken: props.versionId ? props.accessToken : undefined,
     url: `https://api.bentley.com/imodels/${props.iModelId}/namedversions/${props.versionId}`,
   });
-
+  const theme = useThemeWatcher();
   const changesetId = props.versionId ? fetchedVersion?.changesetId : undefined;
-  return (
+  return state || !props.versionId ? (
     <Viewer
       changeSetId={changesetId}
       contextId={props.projectId ?? ""}
       iModelId={props.iModelId ?? ""}
       authConfig={{ oidcClient: AuthClient.client }}
-      theme={useThemeWatcher()}
+      theme={theme}
       backend={{ buddiRegion }}
       uiProviders={[new SimpleBgMapToggleProvider()]}
     />
-  );
+  ) : null;
 };
 
 interface ViewRouterProps extends RouteComponentProps {
@@ -82,7 +83,10 @@ export const ViewRouter = ({ accessToken }: ViewRouterProps) => {
         hideIModelActions={["view"]}
       />
       <View path="project/:projectId/imodel/:iModelId" />
-      <View path="project/:projectId/imodel/:iModelId/version/:versionId" />
+      <View
+        path="project/:projectId/imodel/:iModelId/version/:versionId"
+        accessToken={accessToken}
+      />
     </Router>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1866,14 +1866,14 @@
     react-table "^7.1.0"
     react-transition-group "^4.1.1"
 
-"@itwin/manage-versions-react@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@itwin/manage-versions-react/-/manage-versions-react-0.5.0.tgz#d517f110112db8524957f94a4d0f769f512e6844"
-  integrity sha512-EwToBiZOs5EuiNgAaBQYPkLFGCrqG3wCIYii73E6t8cLFJ+lpFJt6PGbwrPvdQ8c3QFNXCsnN2FzRKi3SxZmrg==
+"@itwin/manage-versions-react@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@itwin/manage-versions-react/-/manage-versions-react-0.7.0.tgz#de95bcb4e7195d8a9c3562b036dc594b615daa8b"
+  integrity sha512-i1ZFLOLeByJK6/k45X75DGOR77dSye/Nnumu4oKcAodPKh7fqPpVXJ3Iw79HKWs1He84d3+YvAyXU4swSQQumA==
   dependencies:
     "@itwin/itwinui-css" "^0.9.0"
     "@itwin/itwinui-icons-react" "^1.2.0"
-    "@itwin/itwinui-react" "^1.6.0"
+    "@itwin/itwinui-react" "^1.11.0"
     classnames "^2.2.6"
 
 "@itwin/viewer-react@1.2.0":


### PR DESCRIPTION
# Named Versions

By using the "Manage versions" page, it is now possible to view the named version. A header button have also been added displaying the current viewed named version or "Latest checkpoint" when none is selected. Clicking on this button will bring the user to the "Manage versions" page itself.

Url will show the version, making it shareable. (However, it will not remember the version if the user move somewhere the named version is not used, (basically, anywhere else than the viewer))

## Manage Versions

Now have url support for tab selection (so ?changes) will display the changes list, instead of the default Named Version list. (and can be bookmarked)