### PR TITLE
fix/clean up silent renew

### DIFF
--- a/packages/app/src/components/Auth/AuthProvider.tsx
+++ b/packages/app/src/components/Auth/AuthProvider.tsx
@@ -51,7 +51,11 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         }
         const client = AuthClient.initialize(auth.clientId, auth.authority);
         client.onUserStateChanged.addListener((token?: AccessToken) => {
-          setIsAuthenticated(token?.isExpired(0) ?? false);
+          console.count("onUserStateChanged");
+          const isAuthd = token?.isExpired(0) ?? false;
+          console.log(isAuthd);
+
+          setIsAuthenticated(!!token);
           setAccessToken(token);
           const userInfo = token?.getUserInfo();
           setUserInfo(userInfo);

--- a/packages/app/src/components/Auth/AuthProvider.tsx
+++ b/packages/app/src/components/Auth/AuthProvider.tsx
@@ -51,10 +51,6 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         }
         const client = AuthClient.initialize(auth.clientId, auth.authority);
         client.onUserStateChanged.addListener((token?: AccessToken) => {
-          console.count("onUserStateChanged");
-          const isAuthd = token?.isExpired(0) ?? false;
-          console.log(isAuthd);
-
           setIsAuthenticated(!!token);
           setAccessToken(token);
           const userInfo = token?.getUserInfo();

--- a/packages/app/src/components/Auth/AuthProvider.tsx
+++ b/packages/app/src/components/Auth/AuthProvider.tsx
@@ -32,7 +32,6 @@ const AuthContext = React.createContext<AuthContextValue>({
 });
 
 export const AuthProvider = ({ children }: AuthProviderProps) => {
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [accessToken, setAccessToken] = useState<AccessToken>();
   const [userInfo, setUserInfo] = useState<UserInfo>();
 
@@ -51,7 +50,6 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         }
         const client = AuthClient.initialize(auth.clientId, auth.authority);
         client.onUserStateChanged.addListener((token?: AccessToken) => {
-          setIsAuthenticated(!!token);
           setAccessToken(token);
           const userInfo = token?.getUserInfo();
           setUserInfo(userInfo);
@@ -65,8 +63,6 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       } catch (error) {
         // if silent sign in fails, have user manually sign in
         await AuthClient.signIn();
-      } finally {
-        setIsAuthenticated(AuthClient.client?.isAuthorized ?? false);
       }
     };
 
@@ -96,7 +92,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   return (
     <AuthContext.Provider
       value={{
-        isAuthenticated,
+        isAuthenticated: !!accessToken,
         isAuthorized,
         accessToken,
         userInfo,

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -4,7 +4,6 @@
  *
  * This code is for demonstration purposes and should not be considered production ready.
  *--------------------------------------------------------------------------------------------*/
-import { Logger, LogLevel } from "@bentley/bentleyjs-core";
 import { BrowserAuthorizationCallbackHandler } from "@bentley/frontend-authorization-client";
 import React from "react";
 import ReactDOM from "react-dom";
@@ -12,10 +11,6 @@ import ReactDOM from "react-dom";
 import App from "./App";
 import "./index.scss";
 import * as serviceWorker from "./serviceWorker";
-
-console.count("index.tsx");
-Logger.initializeToConsole();
-Logger.setLevel("frontend-authorization-client.Authorization", LogLevel.Info);
 
 // Do not render full application if we are handling OIDC callback
 const redirectUrl = new URL(`${window.location.origin}/signin-callback`);

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -4,6 +4,7 @@
  *
  * This code is for demonstration purposes and should not be considered production ready.
  *--------------------------------------------------------------------------------------------*/
+import { Logger, LogLevel } from "@bentley/bentleyjs-core";
 import { BrowserAuthorizationCallbackHandler } from "@bentley/frontend-authorization-client";
 import React from "react";
 import ReactDOM from "react-dom";
@@ -11,6 +12,10 @@ import ReactDOM from "react-dom";
 import App from "./App";
 import "./index.scss";
 import * as serviceWorker from "./serviceWorker";
+
+console.count("index.tsx");
+Logger.initializeToConsole();
+Logger.setLevel("frontend-authorization-client.Authorization", LogLevel.Info);
 
 // Do not render full application if we are handling OIDC callback
 const redirectUrl = new URL(`${window.location.origin}/signin-callback`);

--- a/packages/app/src/services/auth/AuthClient.ts
+++ b/packages/app/src/services/auth/AuthClient.ts
@@ -32,7 +32,8 @@ class AuthClient {
         authority,
       });
       this._client.setAdvancedSettings({
-        silent_redirect_uri: redirectUri,
+        // silent_redirect_uri: redirectUri,
+        accessTokenExpiringNotificationTime: 58 * 60,
       });
     }
     return this._client;

--- a/packages/app/src/services/auth/AuthClient.ts
+++ b/packages/app/src/services/auth/AuthClient.ts
@@ -31,10 +31,6 @@ class AuthClient {
         responseType: "code",
         authority,
       });
-      this._client.setAdvancedSettings({
-        // silent_redirect_uri: redirectUri,
-        accessTokenExpiringNotificationTime: 58 * 60,
-      });
     }
     return this._client;
   }


### PR DESCRIPTION
The oidc-client library will set the silent redirect uri to the redirect uri by default if none is provided.
Found our issue was the isAuthenticated state saved in context and how we checked for it, should've checked `!token?.isExpired(0)`, that the token hadnt expired, but we can do the same with checking if defined 