### PR TITLE
Add Role management

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -60,6 +60,7 @@
     "@types/reach__router": "^1.3.7",
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
+    "msw": "~0.32.0",
     "typescript": "^3.7.2"
   },
   "scripts": {

--- a/packages/app/src/api/projects/generated/api.ts
+++ b/packages/app/src/api/projects/generated/api.ts
@@ -482,7 +482,7 @@ export interface RoleProjectsAPI {
    * @type {string}
    * @memberof RoleProjectsAPI
    */
-  name?: string;
+  displayName?: string;
   /**
    * The description for the role.
    * @type {string}
@@ -495,6 +495,19 @@ export interface RoleProjectsAPI {
    * @memberof RoleProjectsAPI
    */
   permissions?: Array<string>;
+}
+/**
+ *
+ * @export
+ * @interface RoleResponseProjectsAPI
+ */
+export interface RoleResponseProjectsAPI {
+  /**
+   *
+   * @type {RoleProjectsAPI}
+   * @memberof RoleResponseProjectsAPI
+   */
+  role?: RoleProjectsAPI;
 }
 /**
  *
@@ -532,7 +545,13 @@ export interface RolesProjectsAPI {
    * @type {Array<RoleProjectsAPI>}
    * @memberof RolesProjectsAPI
    */
-  value?: Array<RoleProjectsAPI>;
+  roles?: Array<RoleProjectsAPI>;
+  /**
+   *
+   * @type {LinksProjectsAPI}
+   * @memberof RolesProjectsAPI
+   */
+  _links?: LinksProjectsAPI;
 }
 /**
  *
@@ -2018,7 +2037,10 @@ export const ProjectRolesApiFp = function(configuration?: Configuration) {
       body?: RoleCreateProjectsAPI,
       Accept?: string,
       options?: any
-    ): (fetch?: FetchAPI, basePath?: string) => Promise<RoleProjectsAPI> {
+    ): (
+      fetch?: FetchAPI,
+      basePath?: string
+    ) => Promise<RoleResponseProjectsAPI> {
       const localVarFetchArgs = ProjectRolesApiFetchParamCreator(
         configuration
       ).createProjectRole(id, Authorization, body, Accept, options);
@@ -2126,7 +2148,10 @@ export const ProjectRolesApiFp = function(configuration?: Configuration) {
       body?: RoleUpdateProjectsAPI,
       Accept?: string,
       options?: any
-    ): (fetch?: FetchAPI, basePath?: string) => Promise<RoleProjectsAPI> {
+    ): (
+      fetch?: FetchAPI,
+      basePath?: string
+    ) => Promise<RoleResponseProjectsAPI> {
       const localVarFetchArgs = ProjectRolesApiFetchParamCreator(
         configuration
       ).updateProjectRole(id, roleId, Authorization, body, Accept, options);

--- a/packages/app/src/api/projects/openapi/projectsAdjusted.json
+++ b/packages/app/src/api/projects/openapi/projectsAdjusted.json
@@ -793,7 +793,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Role"
+                  "$ref": "#/components/schemas/role-response"
                 },
                 "example": {
                   "role": {
@@ -1948,7 +1948,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Role"
+                  "$ref": "#/components/schemas/role-response"
                 },
                 "example": {
                   "role": {
@@ -2849,6 +2849,14 @@
           }
         }
       },
+      "role-response": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "$ref": "#/components/schemas/Role"
+          }
+        }
+      },
       "Role": {
         "type": "object",
         "properties": {
@@ -2856,7 +2864,7 @@
             "type": "string",
             "description": "The role id."
           },
-          "name": {
+          "displayName": {
             "type": "string",
             "description": "The display name for the role."
           },
@@ -2876,12 +2884,15 @@
       "Roles": {
         "type": "object",
         "properties": {
-          "value": {
+          "roles": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Role"
             },
             "description": "List of roles."
+          },
+          "_links": {
+            "$ref": "#/components/schemas/Links"
           }
         }
       },

--- a/packages/app/src/api/projects/projectsClient.ts
+++ b/packages/app/src/api/projects/projectsClient.ts
@@ -12,6 +12,8 @@ import {
   ProjectRolesApi,
   ProjectsApi,
   ProjectUsersApi,
+  RoleCreateProjectsAPI,
+  RoleUpdateProjectsAPI,
   TeamMemberAddByNamesProjectsAPI,
 } from "./generated";
 
@@ -29,6 +31,66 @@ export class ProjectsClient {
     this.rolesApi = new ProjectRolesApi(undefined, baseUrl);
     this.usersApi = new ProjectUsersApi(undefined, baseUrl);
     this.projectsApi = new ProjectsApi(undefined, baseUrl);
+  }
+
+  /**
+   * See {@link ProjectRolesApi.createProjectRole} for details.
+   * @param projectId
+   * @param role
+   * @returns
+   */
+  async createProjectRole(projectId: string, role: RoleCreateProjectsAPI) {
+    return this.rolesApi.createProjectRole(
+      projectId,
+      this.accessToken,
+      role,
+      ACCEPT
+    );
+  }
+
+  /**
+   * See {@link ProjectRolesApi.updateProjectRole} for details.
+   * @param projectId
+   * @param roleId
+   * @param role
+   * @returns
+   */
+  async updateProjectRole(
+    projectId: string,
+    roleId: string,
+    role: RoleUpdateProjectsAPI
+  ) {
+    return this.rolesApi.updateProjectRole(
+      projectId,
+      roleId,
+      this.accessToken,
+      role,
+      ACCEPT
+    );
+  }
+
+  /**
+   * See {@link ProjectRolesApi.getProjectRoles} for details.
+   * @param projectId
+   * @returns
+   */
+  async getProjectRoles(projectId: string) {
+    return this.rolesApi.getProjectRoles(projectId, this.accessToken, ACCEPT);
+  }
+
+  /**
+   * See {@link ProjectRolesApi.deleteProjectRole} for details.
+   * @param projectId
+   * @param roleId
+   * @returns
+   */
+  async deleteProjectRole(projectId: string, roleId: string) {
+    return this.rolesApi.deleteProjectRole(
+      projectId,
+      roleId,
+      this.accessToken,
+      ACCEPT
+    );
   }
 
   /**
@@ -77,6 +139,27 @@ export class ProjectsClient {
       projectId,
       memberId,
       this.accessToken,
+      ACCEPT
+    );
+  }
+
+  /**
+   * See {@link ProjectUsersApi.updateProjectTeamMemberRoles} for details
+   * @param projectId
+   * @param memberId
+   * @param roleIds
+   * @returns
+   */
+  async updateProjectMemberRoles(
+    projectId: string,
+    memberId: string,
+    roleIds: string[]
+  ) {
+    return this.usersApi.updateProjectTeamMemberRoles(
+      projectId,
+      memberId,
+      this.accessToken,
+      { roleIds },
       ACCEPT
     );
   }

--- a/packages/app/src/routers/MembersRouter/RoleBase.scss
+++ b/packages/app/src/routers/MembersRouter/RoleBase.scss
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *
+ * This code is for demonstration purposes and should not be considered production ready.
+ *--------------------------------------------------------------------------------------------*/
+.idp-scrolling-role-base {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  max-height: 100%;
+
+  > div {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+
+    > .idp-role-base {
+      overflow: hidden;
+      padding: 0;
+
+      > div:first-child {
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+
+        > div:nth-child(2) {
+          overflow: scroll;
+        }
+      }
+    }
+  }
+}

--- a/packages/app/src/routers/MembersRouter/RoleCreate.tsx
+++ b/packages/app/src/routers/MembersRouter/RoleCreate.tsx
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *
+ * This code is for demonstration purposes and should not be considered production ready.
+ *--------------------------------------------------------------------------------------------*/
+import { RouteComponentProps, useNavigate } from "@reach/router";
+import React from "react";
+
+import { CreateRole } from "./components/create-role/CreateRole";
+import { useRoleConfig } from "./useRoleConfig";
+
+interface CreateProps extends RouteComponentProps {
+  accessToken: string;
+  projectId?: string;
+}
+export const RoleCreate = ({ accessToken, projectId = "" }: CreateProps) => {
+  const navigate = useNavigate();
+  const goBack = () => navigate?.(-1);
+  return (
+    <div className={"idp-scrolling-iac-dialog"}>
+      <div className={"idp-content-margins"}>
+        <CreateRole
+          accessToken={accessToken}
+          projectId={projectId}
+          onClose={goBack}
+          onSuccess={goBack}
+          {...useRoleConfig()}
+        />
+      </div>
+    </div>
+  );
+};

--- a/packages/app/src/routers/MembersRouter/RoleCreate.tsx
+++ b/packages/app/src/routers/MembersRouter/RoleCreate.tsx
@@ -8,6 +8,7 @@ import { RouteComponentProps, useNavigate } from "@reach/router";
 import React from "react";
 
 import { CreateRole } from "./components/create-role/CreateRole";
+import "./RoleBase.scss";
 import { useRoleConfig } from "./useRoleConfig";
 
 interface CreateProps extends RouteComponentProps {
@@ -18,7 +19,7 @@ export const RoleCreate = ({ accessToken, projectId = "" }: CreateProps) => {
   const navigate = useNavigate();
   const goBack = () => navigate?.(-1);
   return (
-    <div className={"idp-scrolling-iac-dialog"}>
+    <div className={"idp-scrolling-role-base"}>
       <div className={"idp-content-margins"}>
         <CreateRole
           accessToken={accessToken}

--- a/packages/app/src/routers/MembersRouter/RoleEdit.tsx
+++ b/packages/app/src/routers/MembersRouter/RoleEdit.tsx
@@ -10,6 +10,7 @@ import React from "react";
 import { RolesProjectsAPI } from "../../api/projects/generated";
 import { useApiData } from "../../api/useApiData";
 import { UpdateRole } from "./components/update-role/UpdateRole";
+import "./RoleBase.scss";
 import { useRoleConfig } from "./useRoleConfig";
 
 interface EditProps extends RouteComponentProps {
@@ -24,7 +25,7 @@ const useUpdateRoleLoadingStyler = (loading: boolean) => {
   React.useEffect(() => {
     ref.current
       ?.querySelectorAll(
-        ".iui-input[name=displayName], .iui-input[name=description]"
+        ".iui-input[name=displayName], .iui-input[name=description], .iui-checkbox .iui-label"
       )
       .forEach((element) =>
         element.classList[loading ? "add" : "remove"]("iui-skeleton")
@@ -61,9 +62,9 @@ export const RoleEdit = ({
     navigate?.(-1);
   }, [refreshData, navigate]);
 
-  const { ref } = useUpdateRoleLoadingStyler(!initialRole);
+  const { ref } = useUpdateRoleLoadingStyler(!roles);
   return (
-    <div ref={ref} className={"idp-scrolling-iac-dialog"}>
+    <div ref={ref} className={"idp-scrolling-role-base"}>
       <div className={"idp-content-margins"}>
         <UpdateRole
           key={initialRole.id}

--- a/packages/app/src/routers/MembersRouter/RoleEdit.tsx
+++ b/packages/app/src/routers/MembersRouter/RoleEdit.tsx
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *
+ * This code is for demonstration purposes and should not be considered production ready.
+ *--------------------------------------------------------------------------------------------*/
+import { RouteComponentProps, useNavigate } from "@reach/router";
+import React from "react";
+
+import { RolesProjectsAPI } from "../../api/projects/generated";
+import { useApiData } from "../../api/useApiData";
+import { UpdateRole } from "./components/update-role/UpdateRole";
+import { useRoleConfig } from "./useRoleConfig";
+
+interface EditProps extends RouteComponentProps {
+  accessToken: string;
+  projectId?: string;
+  roleId?: string;
+}
+
+// Not safe, but works for now.
+const useUpdateRoleLoadingStyler = (loading: boolean) => {
+  const ref = React.useRef<HTMLDivElement>(null);
+  React.useEffect(() => {
+    ref.current
+      ?.querySelectorAll(
+        ".iui-input[name=displayName], .iui-input[name=description]"
+      )
+      .forEach((element) =>
+        element.classList[loading ? "add" : "remove"]("iui-skeleton")
+      );
+  }, [loading]);
+  return { ref };
+};
+
+export const RoleEdit = ({
+  accessToken,
+  projectId = "",
+  roleId = "",
+}: EditProps) => {
+  const {
+    results: { roles },
+    refreshData,
+  } = useApiData<RolesProjectsAPI>({
+    accessToken,
+    url: `https://api.bentley.com/projects/${projectId}/roles`,
+  });
+  const initialRole = React.useMemo(() => {
+    const role = roles?.find((role) => role.id === roleId);
+    return {
+      id: role?.id ?? "",
+      displayName: role?.displayName ?? "",
+      description: role?.description ?? "",
+      permissions: role?.permissions ?? [],
+    };
+  }, [roleId, roles]);
+  const navigate = useNavigate();
+  const goBack = () => navigate?.(-1);
+  const refreshAndGoBack = React.useCallback(async () => {
+    await refreshData();
+    navigate?.(-1);
+  }, [refreshData, navigate]);
+
+  const { ref } = useUpdateRoleLoadingStyler(!initialRole);
+  return (
+    <div ref={ref} className={"idp-scrolling-iac-dialog"}>
+      <div className={"idp-content-margins"}>
+        <UpdateRole
+          key={initialRole.id}
+          accessToken={accessToken}
+          projectId={projectId}
+          roleId={roleId}
+          initialRole={initialRole}
+          onClose={goBack}
+          onSuccess={refreshAndGoBack}
+          {...useRoleConfig()}
+        />
+      </div>
+    </div>
+  );
+};

--- a/packages/app/src/routers/MembersRouter/Roles.tsx
+++ b/packages/app/src/routers/MembersRouter/Roles.tsx
@@ -1,0 +1,143 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *
+ * This code is for demonstration purposes and should not be considered production ready.
+ *--------------------------------------------------------------------------------------------*/
+import { SvgAdd, SvgChevronLeft, SvgEdit } from "@itwin/itwinui-icons-react";
+import {
+  Button,
+  ButtonGroup,
+  IconButton,
+  Table,
+  Title,
+} from "@itwin/itwinui-react";
+import { RouteComponentProps } from "@reach/router";
+import React from "react";
+
+import { RoleProjectsAPI } from "../../api/projects/generated";
+import { ProjectsClient } from "../../api/projects/projectsClient";
+import { useApiPrefix } from "../../api/useApiPrefix";
+import { CreateTypeFromInterface } from "../../utils";
+import {
+  SkeletonCell,
+  skeletonRows,
+} from "../SynchronizationRouter/components/SkeletonCell";
+import { RemoveRoleCell } from "./components/RemoveRoleCell";
+import "./Members.scss";
+
+interface RolesProps extends RouteComponentProps {
+  accessToken: string;
+  projectId?: string;
+}
+type Role = CreateTypeFromInterface<RoleProjectsAPI>;
+export const Roles = ({ accessToken, projectId, navigate }: RolesProps) => {
+  const urlPrefix = useApiPrefix();
+
+  const [roles, setRoles] = React.useState<Role[]>(skeletonRows);
+  const [error, setError] = React.useState("");
+  const fetchRoles = React.useCallback(async () => {
+    if (!projectId) {
+      return;
+    }
+    const client = new ProjectsClient(urlPrefix, accessToken);
+    try {
+      const { roles } = await client.getProjectRoles(projectId);
+      setRoles(roles ?? []);
+    } catch (error) {
+      const errorResponse = error as Response;
+      setError(await client.extractAPIErrorMessage(errorResponse));
+    }
+  }, [accessToken, projectId, urlPrefix]);
+  React.useEffect(() => void fetchRoles(), [fetchRoles]);
+
+  return (
+    <div className="idp-scrolling-container members-management">
+      <div className="idp-content-margins">
+        <Title>
+          <IconButton styleType={"borderless"} onClick={() => navigate?.("..")}>
+            <SvgChevronLeft />
+          </IconButton>
+          Project roles management
+        </Title>
+      </div>
+      <div className="idp-content-margins">
+        <Button startIcon={<SvgAdd />} onClick={() => navigate?.("create")}>
+          Create project role
+        </Button>
+      </div>
+      <div className="idp-content-margins idp-scrolling-content">
+        <Table<Role>
+          isSortable={true}
+          expanderCell={() => null}
+          data={roles}
+          columns={React.useMemo(
+            () => [
+              {
+                Header: "Table",
+                columns: [
+                  {
+                    accessor: "displayName",
+                    Cell: SkeletonCell,
+                    Header: "Role",
+                  },
+                  {
+                    accessor: "description",
+                    Cell: SkeletonCell,
+                    Header: "Description",
+                  },
+                  {
+                    accessor: "permissions",
+                    Cell: (props) => (
+                      <SkeletonCell {...props}>
+                        <span
+                          title={(props.value ?? ([] as string[])).join("\n")}
+                        >
+                          {(props.value ?? []).join(", ")}
+                        </span>
+                      </SkeletonCell>
+                    ),
+                    Header: "Permissions",
+                  },
+                  {
+                    id: "actions",
+                    accessor: "id",
+                    maxWidth: 125,
+                    disableSortBy: true,
+                    Cell: (props) => {
+                      const role = React.useMemo(
+                        () => ({
+                          id: props.row.original?.id ?? "",
+                          projectId: projectId ?? "",
+                          displayName: props.row.original.displayName,
+                        }),
+                        [props.row.original.displayName, props.row.original.id]
+                      );
+                      return (
+                        <ButtonGroup>
+                          <IconButton
+                            styleType={"borderless"}
+                            onClick={() => navigate?.(props.value ?? "")}
+                          >
+                            <SvgEdit />
+                          </IconButton>
+                          <RemoveRoleCell
+                            role={role}
+                            accessToken={accessToken}
+                            onSuccess={fetchRoles}
+                          />
+                        </ButtonGroup>
+                      );
+                    },
+                  },
+                ],
+              },
+            ],
+            [accessToken, fetchRoles, navigate, projectId]
+          )}
+          emptyTableContent={error || "No project role, add one above!"}
+        />
+      </div>
+    </div>
+  );
+};

--- a/packages/app/src/routers/MembersRouter/RolesRouter.tsx
+++ b/packages/app/src/routers/MembersRouter/RolesRouter.tsx
@@ -7,23 +7,20 @@
 import { RouteComponentProps, Router } from "@reach/router";
 import React from "react";
 
-import { SelectionRouter } from "../SelectionRouter/SelectionRouter";
-import { Members } from "./Members";
-import { RolesRouter } from "./RolesRouter";
+import { RoleCreate } from "./RoleCreate";
+import { RoleEdit } from "./RoleEdit";
+import { Roles } from "./Roles";
 
-interface MembersRouterProps extends RouteComponentProps {
+interface RolesRouterProps extends RouteComponentProps {
   accessToken: string;
 }
 
-export const MembersRouter = ({ accessToken }: MembersRouterProps) => {
+export const RolesRouter = ({ accessToken }: RolesRouterProps) => {
   return (
     <Router className="full-height-container">
-      <SelectionRouter accessToken={accessToken} path="*" />
-      <Members accessToken={accessToken} path="/project/:projectId/*" />
-      <RolesRouter
-        accessToken={accessToken}
-        path="/project/:projectId/roles/*"
-      />
+      <Roles accessToken={accessToken} path="/" />
+      <RoleCreate accessToken={accessToken} path="/create" />
+      <RoleEdit accessToken={accessToken} path="/:roleId" />
     </Router>
   );
 };

--- a/packages/app/src/routers/MembersRouter/components/EditMemberRoleCell.scss
+++ b/packages/app/src/routers/MembersRouter/components/EditMemberRoleCell.scss
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *
+ * This code is for demonstration purposes and should not be considered production ready.
+ *--------------------------------------------------------------------------------------------*/
+.edit-member-role-cell {
+  cursor: pointer;
+  display: flex;
+  gap: 5px;
+  width: 100%;
+
+  > svg {
+    width: 16px;
+    fill: currentcolor;
+    flex-shrink: 0;
+  }
+}

--- a/packages/app/src/routers/MembersRouter/components/EditMemberRoleCell.tsx
+++ b/packages/app/src/routers/MembersRouter/components/EditMemberRoleCell.tsx
@@ -1,0 +1,209 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *
+ * This code is for demonstration purposes and should not be considered production ready.
+ *--------------------------------------------------------------------------------------------*/
+import { SvgCaretDownSmall, SvgSave } from "@itwin/itwinui-icons-react";
+import {
+  Checkbox,
+  DropdownMenu,
+  MenuItem,
+  ProgressRadial,
+} from "@itwin/itwinui-react";
+import React from "react";
+
+import { RoleProjectsAPI } from "../../../api/projects/generated";
+import { ProjectsClient } from "../../../api/projects/projectsClient";
+import { useApiPrefix } from "../../../api/useApiPrefix";
+import {
+  SkeletonCell,
+  SkeletonCellProps,
+} from "../../SynchronizationRouter/components/SkeletonCell";
+import "./EditMemberRoleCell.scss";
+
+export interface EditMemberRoleCellProps extends SkeletonCellProps {
+  roles: RoleProjectsAPI[];
+  projectId: string;
+  accessToken: string;
+  onDataUpdated(): Promise<void>;
+  onError(errorString: string): void;
+}
+
+export const EditMemberRoleCell = (props: EditMemberRoleCellProps) => {
+  const {
+    value,
+    row,
+    roles,
+    projectId,
+    accessToken,
+    onError,
+    onDataUpdated,
+  } = props;
+  const urlPrefix = useApiPrefix();
+  const propRoles = value as string[];
+  const userId = row?.original?.userId;
+  const [userRoles, setUserRoles] = React.useState<{
+    [role: string]: boolean;
+  }>({});
+  const resetMenu = React.useCallback(() => {
+    if (!propRoles) {
+      setUserRoles((roles) => {
+        if (Object.keys(roles).length > 0) {
+          return {};
+        }
+        return roles;
+      });
+      return;
+    }
+    const currentRoles: { [role: string]: boolean } = {};
+    for (const role of propRoles) {
+      const projectRole = roles.find((r) => r.displayName === role);
+      if (projectRole?.id) {
+        currentRoles[projectRole.id] = true;
+      } else {
+        currentRoles[role] = true;
+      }
+    }
+    setUserRoles(currentRoles);
+  }, [propRoles, roles]);
+  React.useEffect(() => resetMenu(), [resetMenu]);
+
+  const [working, setWorking] = React.useState(false);
+  const buildCheckbox = React.useCallback(
+    (role: RoleProjectsAPI, key: string | number) => (
+      <CheckBoxMenuItem
+        key={key}
+        onChange={(event) => {
+          const {
+            target: { checked, value },
+          } = event;
+          setUserRoles((roles) => ({
+            ...roles,
+            [value]: checked,
+          }));
+        }}
+        value={role.id}
+        disabled={working || role.id === "Team Member"}
+        label={role.displayName}
+        defaultChecked={userRoles[role?.id ?? ""]}
+      />
+    ),
+    [userRoles, working]
+  );
+  const saveRoles = React.useCallback(
+    async (close: () => void) => {
+      if (!projectId) {
+        close();
+        return;
+      }
+      setWorking(true);
+      const client = new ProjectsClient(urlPrefix, accessToken);
+      try {
+        const roleIds = [];
+        for (const role in userRoles) {
+          if (Object.prototype.hasOwnProperty.call(userRoles, role)) {
+            const enabled = userRoles[role] && role !== "Team Member";
+            if (enabled) {
+              roleIds.push(role);
+            }
+          }
+        }
+        await client.updateProjectMemberRoles(projectId, userId, roleIds);
+      } catch (error) {
+        const errorResponse = error as Response;
+        onError(await client.extractAPIErrorMessage(errorResponse));
+      }
+      setWorking(false);
+      close();
+      await onDataUpdated();
+    },
+    [
+      accessToken,
+      onDataUpdated,
+      onError,
+      projectId,
+      urlPrefix,
+      userId,
+      userRoles,
+    ]
+  );
+
+  return (
+    <SkeletonCell {...props}>
+      <DropdownMenu
+        onHidden={resetMenu}
+        menuItems={React.useCallback(
+          (close) => [
+            buildCheckbox(
+              {
+                id: "Team Member",
+                displayName: "Team Member",
+              },
+              "Team Member"
+            ),
+            ...roles.map(buildCheckbox),
+            <MenuItem
+              key={"saveRoles"}
+              //isSelected={true}
+              icon={
+                working ? (
+                  <ProgressRadial size={"small"} indeterminate={true} />
+                ) : (
+                  <SvgSave />
+                )
+              }
+              disabled={working}
+              onClick={() => saveRoles(close)}
+            >
+              Apply roles changes
+            </MenuItem>,
+          ],
+          [buildCheckbox, roles, saveRoles, working]
+        )}
+      >
+        <div className={"edit-member-role-cell"}>
+          <span title={(value ?? ([] as string[])).join("\n")}>
+            {(value ?? []).join(", ")}
+          </span>
+          <SvgCaretDownSmall />
+        </div>
+      </DropdownMenu>
+    </SkeletonCell>
+  );
+};
+
+const CheckBoxMenuItem = ({
+  key,
+  disabled,
+  onChange,
+  value,
+  label,
+  defaultChecked,
+}: {
+  key: string | number;
+  disabled: boolean;
+  onChange: React.ChangeEventHandler<HTMLInputElement>;
+  value: string | undefined;
+  label: string | undefined;
+  defaultChecked: boolean;
+}) => {
+  const ref = React.useRef<HTMLInputElement>(null);
+  return (
+    <MenuItem
+      onClick={() => ref.current?.click()}
+      key={key}
+      disabled={disabled}
+    >
+      <Checkbox
+        ref={ref}
+        style={{ pointerEvents: "none" }}
+        onChange={onChange}
+        value={value}
+        disabled={disabled}
+        label={label}
+        defaultChecked={defaultChecked}
+      />
+    </MenuItem>
+  );
+};

--- a/packages/app/src/routers/MembersRouter/components/RemoveRoleCell.tsx
+++ b/packages/app/src/routers/MembersRouter/components/RemoveRoleCell.tsx
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *
+ * This code is for demonstration purposes and should not be considered production ready.
+ *--------------------------------------------------------------------------------------------*/
+import { SvgRemove } from "@itwin/itwinui-icons-react";
+import { IconButton } from "@itwin/itwinui-react";
+import React from "react";
+
+import { useApiPrefix } from "../../../api/useApiPrefix";
+import { DeleteRole, DeleteRoleProps } from "./delete-role/DeleteRole";
+
+type RemoveRoleCellProps = Required<
+  Pick<DeleteRoleProps, "accessToken" | "role" | "onSuccess">
+>;
+
+export const RemoveRoleCell = ({
+  role,
+  accessToken,
+  onSuccess,
+}: RemoveRoleCellProps) => {
+  const [showDialog, setShowDialog] = React.useState(false);
+  const urlPrefix = useApiPrefix();
+  const apiOverrides: DeleteRoleProps["apiOverrides"] = React.useMemo(
+    () => ({ serverEnvironmentPrefix: urlPrefix }),
+    [urlPrefix]
+  );
+  const showDeleteUserDialog = async () => {
+    if (!role.projectId || !role.id) {
+      return;
+    }
+    setShowDialog(true);
+  };
+
+  const close = async () => {
+    setShowDialog(false);
+  };
+
+  return (
+    <>
+      <IconButton
+        styleType="borderless"
+        title="Remove member"
+        onClick={showDeleteUserDialog}
+      >
+        <SvgRemove />
+      </IconButton>
+      {showDialog && (
+        <DeleteRole
+          apiOverrides={apiOverrides}
+          accessToken={accessToken}
+          role={role}
+          onClose={close}
+          onError={close}
+          onSuccess={() => {
+            setShowDialog(false);
+            onSuccess();
+          }}
+        />
+      )}
+    </>
+  );
+};

--- a/packages/app/src/routers/MembersRouter/components/base-role/BaseRole.scss
+++ b/packages/app/src/routers/MembersRouter/components/base-role/BaseRole.scss
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *
+ * This code is for demonstration purposes and should not be considered production ready.
+ *--------------------------------------------------------------------------------------------*/
+@import "~@itwin/itwinui-css/scss/variables";
+
+.idp-role-base {
+  padding: $iui-xl;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: space-between;
+
+  .overlay-container {
+    position: fixed;
+    z-index: 99999;
+    background-color: rgba(0, 0, 0, 0.1);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    width: 100vw;
+    top: 0;
+    left: 0;
+  }
+
+  .button-bar {
+    width: 100%;
+    margin-bottom: $iui-xl;
+    display: flex;
+    justify-content: center;
+    margin-top: $iui-m;
+
+    > :first-child {
+      margin-right: $iui-m;
+    }
+  }
+
+  .inputs-container {
+    justify-content: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    > .iui-input-container {
+      width: 100%;
+      max-width: 600px;
+    }
+
+    > * {
+      margin-bottom: $iui-m;
+    }
+  }
+}

--- a/packages/app/src/routers/MembersRouter/components/base-role/BaseRole.scss
+++ b/packages/app/src/routers/MembersRouter/components/base-role/BaseRole.scss
@@ -30,11 +30,17 @@
     width: 100%;
     margin-bottom: $iui-xl;
     display: flex;
-    justify-content: center;
+    flex-direction: column;
+    align-items: center;
     margin-top: $iui-m;
 
-    > :first-child {
-      margin-right: $iui-m;
+    > div {
+      display: flex;
+      justify-content: center;
+
+      > :first-child {
+        margin-right: $iui-m;
+      }
     }
   }
 

--- a/packages/app/src/routers/MembersRouter/components/base-role/BaseRole.test.tsx
+++ b/packages/app/src/routers/MembersRouter/components/base-role/BaseRole.test.tsx
@@ -1,0 +1,94 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *
+ * This code is for demonstration purposes and should not be considered production ready.
+ *--------------------------------------------------------------------------------------------*/
+import { fireEvent, render } from "@testing-library/react";
+import React from "react";
+
+import { BaseRolePage } from "./BaseRole";
+
+describe("BaseRole", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should show base page", () => {
+    const actionMock = jest.fn();
+    const closeMock = jest.fn();
+
+    const { container, getByText } = render(
+      <BaseRolePage onActionClick={actionMock} onClose={closeMock} />
+    );
+
+    getByText("Create a role");
+
+    expect(
+      container.querySelector(".idp-role-base .inputs-container .name-input")
+    ).toBeTruthy();
+    expect(
+      container.querySelector(
+        ".idp-role-base .inputs-container .description-input"
+      )
+    ).toBeTruthy();
+
+    const confirmButton = container.querySelector(
+      ".idp-role-base .button-bar button:first-child"
+    ) as HTMLButtonElement;
+    expect(confirmButton.disabled).toBe(true);
+    expect(confirmButton.textContent).toBe("Create");
+    confirmButton.click();
+    expect(actionMock).not.toHaveBeenCalled();
+    const cancelButton = container.querySelector(
+      ".idp-role-base .button-bar button:last-child"
+    ) as HTMLButtonElement;
+    cancelButton.click();
+    expect(closeMock).toHaveBeenCalled();
+  });
+
+  it("should show overlay spinner", () => {
+    const { container } = render(<BaseRolePage isLoading />);
+
+    expect(
+      container.querySelector(".idp-role-base .overlay-container")
+    ).toBeTruthy();
+  });
+
+  it("should show error message for too long string", async () => {
+    const { container, getByText } = render(<BaseRolePage />);
+
+    const name = container.querySelector(
+      ".idp-role-base .inputs-container .name-input"
+    ) as HTMLInputElement;
+    fireEvent.change(name, { target: { value: new Array(260).join("a") } });
+    getByText("The value exceeds allowed 255 characters.");
+    const confirmButton = container.querySelector(
+      ".idp-role-base .button-bar button:first-child"
+    ) as HTMLButtonElement;
+    expect(confirmButton.disabled).toBe(true);
+  });
+
+  it("should show base page with filled values", () => {
+    const { container } = render(
+      <BaseRolePage
+        initialRole={{
+          displayName: "Some name",
+          description: "Some description",
+        }}
+      />
+    );
+
+    const name = container.querySelector(
+      ".idp-role-base .inputs-container .name-input"
+    ) as HTMLInputElement;
+    expect(name).toBeTruthy();
+    expect(name.value).toBe("Some name");
+
+    const description = container.querySelector(
+      ".idp-role-base .inputs-container .description-input"
+    ) as HTMLInputElement;
+    expect(description).toBeTruthy();
+    expect(description.value).toBe("Some description");
+  });
+});

--- a/packages/app/src/routers/MembersRouter/components/base-role/BaseRole.tsx
+++ b/packages/app/src/routers/MembersRouter/components/base-role/BaseRole.tsx
@@ -1,0 +1,256 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *
+ * This code is for demonstration purposes and should not be considered production ready.
+ *--------------------------------------------------------------------------------------------*/
+import {
+  Button,
+  Checkbox,
+  InputGroup,
+  LabeledInput,
+  ProgressRadial,
+  Title,
+} from "@itwin/itwinui-react";
+import React from "react";
+
+import { RoleCreateProjectsAPI } from "../../../../api/projects/generated";
+import { spreadIf } from "../../../../utils";
+import "./BaseRole.scss";
+
+export type BaseRole = RoleCreateProjectsAPI & {
+  permissions?: string[];
+};
+
+export type PermissionOption = {
+  /** string value of the permission this options toggles */
+  permission: string;
+};
+
+export type BaseRoleProps = {
+  /** Callback on canceled action. */
+  onClose?: () => void;
+  /** Callback on action. */
+  onActionClick?: (role: {
+    displayName: string;
+    description: string;
+    permissions: string[];
+  }) => void;
+  /** Object of string overrides. */
+  stringsOverrides?: {
+    /** The title of the page. */
+    titleString?: string;
+    /** Role name property. */
+    displayNameString?: string;
+    /** Role description property. */
+    descriptionString?: string;
+    /** Confirm button string. */
+    confirmButton?: string;
+    /** Cancel button string. */
+    cancelButton?: string;
+    /** Error message when name is too long. */
+    displayNameTooLong?: string;
+    /** Error message when description is too long. */
+    descriptionTooLong?: string;
+  };
+  /** If action is loading. */
+  isLoading?: boolean;
+  /** Initial role state used for update. */
+  initialRole?: BaseRole;
+  /** Permission options to display */
+  permissionsOptions?: PermissionOption[];
+};
+
+const MAX_LENGTH = 255;
+
+export function BaseRolePage(props: BaseRoleProps) {
+  const {
+    onClose,
+    onActionClick,
+    initialRole,
+    isLoading = false,
+    stringsOverrides,
+    permissionsOptions = [],
+  } = props;
+  const [role, setRole] = React.useState<Required<BaseRole>>({
+    displayName: initialRole?.displayName ?? "",
+    description: initialRole?.description ?? "",
+    permissions: initialRole?.permissions ?? [],
+  });
+
+  const initialPermissions = initialRole?.permissions;
+
+  const updatedStrings = {
+    titleString: "Create a role",
+    displayNameString: "Name",
+    descriptionString: "Description",
+    confirmButton: "Create",
+    cancelButton: "Cancel",
+    displayNameTooLong: `The value exceeds allowed ${MAX_LENGTH} characters.`,
+    descriptionTooLong: `The value exceeds allowed ${MAX_LENGTH} characters.`,
+    ...stringsOverrides,
+  };
+
+  const onPropChange = (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const {
+      target: { name, value },
+    } = event;
+    setRole((prevState) => ({
+      ...prevState,
+      [name]: value ?? "",
+    }));
+  };
+  const onCheckChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const {
+      target: { value, checked },
+    } = event;
+    setRole((prevState) => ({
+      ...prevState,
+      permissions: [
+        ...prevState.permissions.filter((permission) => permission !== value),
+        ...spreadIf(checked && value),
+      ],
+    }));
+  };
+
+  const isPropertyInvalid = (value: string) => {
+    return value.length > MAX_LENGTH;
+  };
+
+  const isDataValid = () => {
+    return (
+      !!role.displayName.length &&
+      !isPropertyInvalid(role.displayName) &&
+      !isPropertyInvalid(role.description)
+    );
+  };
+
+  const isDataChanged = () => {
+    return (
+      role.displayName !== initialRole?.displayName ||
+      role.description !== initialRole?.description ||
+      role.permissions.length !== initialRole?.permissions?.length ||
+      !role.permissions.every((permission) =>
+        initialRole.permissions?.includes(permission)
+      )
+    );
+  };
+
+  const unknownPermissions = React.useMemo(
+    () =>
+      initialPermissions?.filter(
+        (permission) =>
+          !permissionsOptions.some((option) => option.permission === permission)
+      ) ?? [],
+    [initialPermissions, permissionsOptions]
+  );
+  const uiDisabled = unknownPermissions.length > 0;
+  return (
+    <div className="idp-role-base">
+      <div>
+        <Title>{updatedStrings.titleString}</Title>
+        <div>
+          <div className="inputs-container">
+            <LabeledInput
+              label={updatedStrings.displayNameString}
+              inputClassName={"name-input"}
+              name="displayName"
+              setFocus={true}
+              required={true}
+              value={role.displayName}
+              onChange={onPropChange}
+              disabled={uiDisabled}
+              message={
+                isPropertyInvalid(role.displayName)
+                  ? updatedStrings.displayNameTooLong
+                  : undefined
+              }
+              status={
+                isPropertyInvalid(role.displayName) ? "negative" : undefined
+              }
+              autoComplete="off"
+            />
+            <LabeledInput
+              label={updatedStrings.descriptionString ?? "Description"}
+              name="description"
+              inputClassName={"description-input"}
+              disabled={uiDisabled}
+              value={role.description}
+              onChange={onPropChange}
+              message={
+                isPropertyInvalid(role.description)
+                  ? updatedStrings.descriptionTooLong
+                  : undefined
+              }
+              status={
+                isPropertyInvalid(role.description) ? "negative" : undefined
+              }
+              autoComplete="off"
+            />
+            {permissionsOptions.length > 0 && (
+              <InputGroup label="Permissions">
+                {permissionsOptions.map((option) => (
+                  <Checkbox
+                    label={option.permission}
+                    value={option.permission}
+                    onChange={onCheckChange}
+                    key={option.permission}
+                    checked={role.permissions.includes(option.permission)}
+                    disabled={uiDisabled}
+                  />
+                ))}
+              </InputGroup>
+            )}
+            {unknownPermissions.length > 0 && (
+              <InputGroup
+                label="Unmanaged permissions"
+                message={
+                  "This role contains permissions that are not managed by this demo portal, update to this role is not available."
+                }
+                status={"warning"}
+              >
+                {unknownPermissions.map((permission) => (
+                  <Checkbox
+                    status={"warning"}
+                    disabled={true}
+                    label={permission}
+                    value={permission}
+                    key={permission}
+                    checked={true}
+                  />
+                ))}
+              </InputGroup>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="button-bar">
+        <Button
+          styleType="cta"
+          disabled={
+            !isDataChanged() || !isDataValid() || isLoading || uiDisabled
+          }
+          onClick={() =>
+            onActionClick?.({
+              ...role,
+            })
+          }
+        >
+          {updatedStrings.confirmButton}
+        </Button>
+        <Button onClick={onClose}>{updatedStrings.cancelButton}</Button>
+      </div>
+      {isLoading && <OverlaySpinner />}
+    </div>
+  );
+}
+
+function OverlaySpinner() {
+  return (
+    <div className="overlay-container">
+      <ProgressRadial indeterminate />
+    </div>
+  );
+}

--- a/packages/app/src/routers/MembersRouter/components/base-role/BaseRole.tsx
+++ b/packages/app/src/routers/MembersRouter/components/base-role/BaseRole.tsx
@@ -44,6 +44,10 @@ export type BaseRoleProps = {
     displayNameString?: string;
     /** Role description property. */
     descriptionString?: string;
+    /** Role permissions property. */
+    permissionsString?: string;
+    /** Role unknown permissions list title */
+    unknownPermissionsString?: string;
     /** Confirm button string. */
     confirmButton?: string;
     /** Cancel button string. */
@@ -52,6 +56,8 @@ export type BaseRoleProps = {
     displayNameTooLong?: string;
     /** Error message when description is too long. */
     descriptionTooLong?: string;
+    /** Warning message when unkown roles are present */
+    unknownPermissionsWarning?: string;
   };
   /** If action is loading. */
   isLoading?: boolean;
@@ -88,6 +94,10 @@ export function BaseRolePage(props: BaseRoleProps) {
     cancelButton: "Cancel",
     displayNameTooLong: `The value exceeds allowed ${MAX_LENGTH} characters.`,
     descriptionTooLong: `The value exceeds allowed ${MAX_LENGTH} characters.`,
+    permissionsString: "Permissions",
+    unknownPermissionsString: "Unmanaged permissions",
+    unknownPermissionsWarning:
+      "This role contains permissions that are not managed by this demo portal, update to this role is not available.",
     ...stringsOverrides,
   };
 
@@ -190,7 +200,7 @@ export function BaseRolePage(props: BaseRoleProps) {
               autoComplete="off"
             />
             {permissionsOptions.length > 0 && (
-              <InputGroup label="Permissions">
+              <InputGroup label={updatedStrings.permissionsString}>
                 {permissionsOptions.map((option) => (
                   <Checkbox
                     label={option.permission}
@@ -204,13 +214,7 @@ export function BaseRolePage(props: BaseRoleProps) {
               </InputGroup>
             )}
             {unknownPermissions.length > 0 && (
-              <InputGroup
-                label="Unmanaged permissions"
-                message={
-                  "This role contains permissions that are not managed by this demo portal, update to this role is not available."
-                }
-                status={"warning"}
-              >
+              <InputGroup label={updatedStrings.unknownPermissionsString}>
                 {unknownPermissions.map((permission) => (
                   <Checkbox
                     status={"warning"}
@@ -227,20 +231,29 @@ export function BaseRolePage(props: BaseRoleProps) {
         </div>
       </div>
       <div className="button-bar">
-        <Button
-          styleType="cta"
-          disabled={
-            !isDataChanged() || !isDataValid() || isLoading || uiDisabled
-          }
-          onClick={() =>
-            onActionClick?.({
-              ...role,
-            })
-          }
-        >
-          {updatedStrings.confirmButton}
-        </Button>
-        <Button onClick={onClose}>{updatedStrings.cancelButton}</Button>
+        {uiDisabled && (
+          <LabeledInput
+            inputStyle={{ display: "none" }}
+            message={updatedStrings.unknownPermissionsWarning}
+            status={"warning"}
+          />
+        )}
+        <div>
+          <Button
+            styleType="cta"
+            disabled={
+              !isDataChanged() || !isDataValid() || isLoading || uiDisabled
+            }
+            onClick={() =>
+              onActionClick?.({
+                ...role,
+              })
+            }
+          >
+            {updatedStrings.confirmButton}
+          </Button>
+          <Button onClick={onClose}>{updatedStrings.cancelButton}</Button>
+        </div>
       </div>
       {isLoading && <OverlaySpinner />}
     </div>

--- a/packages/app/src/routers/MembersRouter/components/create-role/CreateRole.test.tsx
+++ b/packages/app/src/routers/MembersRouter/components/create-role/CreateRole.test.tsx
@@ -1,0 +1,175 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *
+ * This code is for demonstration purposes and should not be considered production ready.
+ *--------------------------------------------------------------------------------------------*/
+import { toaster } from "@itwin/itwinui-react";
+import { act, fireEvent, render } from "@testing-library/react";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
+import React from "react";
+
+import { CreateRole } from "./CreateRole";
+
+jest.mock("isomorphic-fetch", () => jest.requireActual("node-fetch"));
+const requestMock = jest.fn();
+const mockedRole = { role: { id: "dd", displayName: "name" } };
+const server = setupServer(
+  rest.post(
+    "https://api.bentley.com/projects/:projectId/roles",
+    (req, res, ctx) => {
+      requestMock({
+        projectId: req.params["projectId"],
+        body: req.body,
+      });
+      return res(ctx.status(200), ctx.json(mockedRole));
+    }
+  ),
+  rest.patch(
+    "https://api.bentley.com/projects/:projectId/roles/:roleId",
+    (req, res, ctx) => {
+      requestMock({
+        projectId: req.params["projectId"],
+        roleId: req.params["roleId"],
+        body: req.body,
+      });
+      return res(ctx.status(200), ctx.json(mockedRole));
+    }
+  )
+);
+
+describe("CreateRole", () => {
+  // Enable API mocking before tests.
+  beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+
+  // Reset any runtime request handlers we may add during the tests.
+  afterEach(() => {
+    jest.clearAllMocks();
+    server.resetHandlers();
+  });
+
+  // Disable API mocking after the tests are done.
+  afterAll(() => server.close());
+
+  it("should create a project", async () => {
+    const successMock = jest.fn();
+    toaster.positive = jest.fn();
+
+    const { getByText, container } = render(
+      <CreateRole projectId="pid" accessToken="dd" onSuccess={successMock} />
+    );
+
+    const name = container.querySelector(
+      "input[name=displayName]"
+    ) as HTMLInputElement;
+    fireEvent.change(name, {
+      target: { value: "Some name" },
+    });
+
+    const description = container.querySelector(
+      "input[name=description]"
+    ) as HTMLInputElement;
+    fireEvent.change(description, {
+      target: { value: "Some description" },
+    });
+
+    const createButton = getByText("Create");
+    await act(
+      () =>
+        new Promise((resolve) => {
+          successMock.mockImplementationOnce(resolve);
+          createButton.click();
+        })
+    );
+
+    expect(requestMock).toHaveBeenCalledWith({
+      projectId: "pid",
+      body: {
+        displayName: "Some name",
+        description: "Some description",
+      },
+    });
+    expect(requestMock).toHaveBeenCalledWith({
+      projectId: "pid",
+      roleId: "dd",
+      body: {
+        displayName: "Some name",
+        description: "Some description",
+        permissions: [],
+      },
+    });
+    expect(successMock).toHaveBeenCalledWith(mockedRole);
+    expect(toaster.positive).toHaveBeenCalledWith(
+      "Role created successfully.",
+      {
+        hasCloseButton: true,
+      }
+    );
+  });
+
+  it("should show general error", async () => {
+    const errorMock = jest.fn();
+    toaster.negative = jest.fn();
+    const error = {
+      error: {
+        message: "User is not authorized",
+        code: "Unauthorized",
+      },
+    };
+    server.use(
+      rest.post(
+        "https://api.bentley.com/projects/:projectId/roles",
+        (req, res, ctx) => {
+          requestMock({
+            projectId: req.params["projectId"],
+            body: req.body,
+          });
+          return res(ctx.status(401), ctx.json(error));
+        }
+      )
+    );
+
+    const { getByText, container } = render(
+      <CreateRole projectId="errorPid" accessToken="dd" onError={errorMock} />
+    );
+
+    const name = container.querySelector(
+      "input[name=displayName]"
+    ) as HTMLInputElement;
+    fireEvent.change(name, {
+      target: { value: "Some name" },
+    });
+
+    const number = container.querySelector(
+      "input[name=description]"
+    ) as HTMLInputElement;
+    fireEvent.change(number, {
+      target: { value: "Some description" },
+    });
+
+    const createButton = getByText("Create");
+    await act(
+      () =>
+        new Promise((resolve) => {
+          errorMock.mockImplementationOnce(resolve);
+          createButton.click();
+        })
+    );
+
+    expect(requestMock).toHaveBeenCalledWith({
+      projectId: "errorPid",
+      body: {
+        displayName: "Some name",
+        description: "Some description",
+      },
+    });
+    expect(errorMock).toHaveBeenCalledWith(error);
+    expect(toaster.negative).toHaveBeenCalledWith(
+      "Could not create a role. Please try again later.",
+      {
+        hasCloseButton: true,
+      }
+    );
+  });
+});

--- a/packages/app/src/routers/MembersRouter/components/create-role/CreateRole.tsx
+++ b/packages/app/src/routers/MembersRouter/components/create-role/CreateRole.tsx
@@ -1,0 +1,139 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *
+ * This code is for demonstration purposes and should not be considered production ready.
+ *--------------------------------------------------------------------------------------------*/
+import { toaster } from "@itwin/itwinui-react";
+import React from "react";
+
+import { RoleProjectsAPI } from "../../../../api/projects/generated";
+import { ProjectsClient } from "../../../../api/projects/projectsClient";
+import { BaseRolePage, PermissionOption } from "../base-role/BaseRole";
+
+export type CreateRoleProps = {
+  /** Bearer access token with scope `projects:modify`. */
+  accessToken: string;
+  /** Object that configures different overrides for the API. */
+  apiOverrides?: { serverEnvironmentPrefix?: "dev" | "qa" | "" };
+  /** Callback on canceled action. */
+  onClose?: () => void;
+  /** Callback on failed create. */
+  onError?: (
+    error: { error: { code?: string; message?: string } } | any
+  ) => void;
+  /** Callback on successful create. */
+  onSuccess?: (createdRole: { role?: RoleProjectsAPI }) => void;
+  /** Object of string overrides. */
+  stringsOverrides?: {
+    /** Displayed after successful create. */
+    successMessage?: string;
+    /** Displayed after failed create. */
+    errorMessage?: string;
+    /** Displayed after failed create because of the duplicate name or number. */
+    errorMessageRoleExists?: string;
+    /** The title of the page. */
+    titleString?: string;
+    /** Role name property. */
+    nameString?: string;
+    /** Role description property. */
+    descriptionString?: string;
+    /** Confirm button string. */
+    confirmButton?: string;
+    /** Cancel button string. */
+    cancelButton?: string;
+    /** Error message when name is too long. */
+    displayNameTooLong?: string;
+    /** Error message when description is too long. */
+    descriptionTooLong?: string;
+  };
+  /** ProjectId where to create an role. */
+  projectId: string;
+  /** Permission options to display */
+  permissionsOptions?: PermissionOption[];
+};
+
+export function CreateRole(props: CreateRoleProps) {
+  const {
+    accessToken,
+    apiOverrides = { serverEnvironmentPrefix: "" },
+    onClose,
+    onError,
+    onSuccess,
+    stringsOverrides,
+    projectId,
+    permissionsOptions,
+  } = props;
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const updatedStrings = {
+    successMessage: "Role created successfully.",
+    errorMessage: "Could not create a role. Please try again later.",
+    errorMessageRoleExists: "Role with the same name or number already exists.",
+    ...stringsOverrides,
+  };
+
+  const createRole = async (fullRole: {
+    displayName: string;
+    description: string;
+    permissions: string[];
+  }) => {
+    setIsLoading(true);
+    try {
+      const client = new ProjectsClient(
+        apiOverrides?.serverEnvironmentPrefix ?? "",
+        accessToken
+      );
+      const { permissions, ...role } = fullRole;
+      const createdRole = await client.createProjectRole(projectId, role);
+      if (!createdRole.role?.id) {
+        throw new Error("Role creation failed");
+      }
+      const finalRole = await client.updateProjectRole(
+        projectId,
+        createdRole.role.id,
+        fullRole
+      );
+
+      setIsLoading(false);
+      toaster.positive(updatedStrings.successMessage, {
+        hasCloseButton: true,
+      });
+      onSuccess?.(finalRole);
+    } catch (err) {
+      const responseError = err as Response;
+      let error = new Error();
+      if (responseError?.json) {
+        const responseBody = await responseError.json();
+        error = { ...error, ...responseBody };
+      } else {
+        error = { ...error, ...responseError };
+      }
+      handleError(error);
+    }
+  };
+
+  const handleError = (
+    error: { error: { code?: string; message?: string } } | any
+  ) => {
+    setIsLoading(false);
+    const errorString =
+      error?.error?.code === "RoleExists"
+        ? updatedStrings.errorMessageRoleExists
+        : updatedStrings.errorMessage;
+    toaster.negative(errorString, { hasCloseButton: true });
+    onError?.(error);
+  };
+
+  return (
+    <>
+      <BaseRolePage
+        stringsOverrides={updatedStrings}
+        isLoading={isLoading}
+        onActionClick={createRole}
+        onClose={onClose}
+        permissionsOptions={permissionsOptions}
+      />
+    </>
+  );
+}

--- a/packages/app/src/routers/MembersRouter/components/delete-role/DeleteRole.scss
+++ b/packages/app/src/routers/MembersRouter/components/delete-role/DeleteRole.scss
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *
+ * This code is for demonstration purposes and should not be considered production ready.
+ *--------------------------------------------------------------------------------------------*/
+@import "~@itwin/itwinui-css/scss/variables";
+
+.idp-delete-role-title {
+  display: flex;
+  align-items: center;
+
+  .warning-icon {
+    width: $iui-m;
+    height: $iui-m;
+    margin-right: $iui-s;
+    @include themed {
+      fill: t(iui-color-foreground-warning);
+    }
+  }
+
+  &.overlay-container {
+    position: fixed;
+    z-index: 99999;
+    background-color: rgba(0, 0, 0, 0.3);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    width: 100vw;
+    top: 0;
+    left: 0;
+  }
+}

--- a/packages/app/src/routers/MembersRouter/components/delete-role/DeleteRole.test.tsx
+++ b/packages/app/src/routers/MembersRouter/components/delete-role/DeleteRole.test.tsx
@@ -1,0 +1,146 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *
+ * This code is for demonstration purposes and should not be considered production ready.
+ *--------------------------------------------------------------------------------------------*/
+import { act, render } from "@testing-library/react";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
+import React from "react";
+
+import { DeleteRole } from "./DeleteRole";
+
+jest.mock("isomorphic-fetch", () => jest.requireActual("node-fetch"));
+const requestMock = jest.fn();
+const server = setupServer(
+  rest.delete(
+    "https://api.bentley.com/projects/:projectId/roles/:roleId",
+    (req, res, ctx) => {
+      requestMock();
+      return res(ctx.status(200));
+    }
+  )
+);
+
+describe("DeleteProject", () => {
+  // Enable API mocking before tests.
+  beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+
+  // Reset any runtime request handlers we may add during the tests.
+  afterEach(() => {
+    requestMock.mockClear();
+    server.resetHandlers();
+  });
+
+  // Disable API mocking after the tests are done.
+  afterAll(() => server.close());
+
+  it("should open delete modal", () => {
+    const { getByText } = render(
+      <DeleteRole
+        role={{
+          id: "111",
+          displayName: "test role",
+          projectId: "222",
+        }}
+        accessToken="dd"
+      />
+    );
+
+    const title = document.querySelector(
+      ".idp-delete-role-title"
+    ) as HTMLElement;
+    expect(title.textContent).toBe(`Delete role 'test role'`);
+    expect(
+      title.querySelector(".idp-delete-role-title .warning-icon")
+    ).toBeTruthy();
+    getByText(
+      "Deleting this role will remove it for all users. Are you sure you want to delete this role?"
+    );
+  });
+
+  it("should delete role", async () => {
+    const successMock = jest.fn();
+
+    const { getByText } = render(
+      <DeleteRole
+        role={{
+          id: "111",
+          displayName: "test project",
+          projectId: "222",
+        }}
+        accessToken="dd"
+        onSuccess={successMock}
+      />
+    );
+
+    const button = getByText("Yes") as HTMLButtonElement;
+    await act(
+      () =>
+        new Promise<void>((resolve) => {
+          successMock.mockImplementationOnce(resolve);
+          button.click();
+        })
+    );
+    expect(requestMock).toHaveBeenCalled();
+    expect(successMock).toHaveBeenCalled();
+  });
+
+  it("should return error when failed to delete role", async () => {
+    const failureMock = jest.fn();
+    const error = { message: "Error", code: "500" };
+    server.use(
+      rest.delete(
+        "https://api.bentley.com/projects/:projectId/roles/:roleId",
+        (req, res, ctx) => {
+          requestMock();
+          return res(ctx.status(500), ctx.json(error));
+        }
+      )
+    );
+    const { getByText } = render(
+      <DeleteRole
+        role={{
+          id: "111",
+          displayName: "test project",
+          projectId: "222",
+        }}
+        accessToken="dd"
+        onError={failureMock}
+      />
+    );
+
+    const button = getByText("Yes") as HTMLButtonElement;
+    await act(
+      () =>
+        new Promise<void>((resolve) => {
+          failureMock.mockImplementationOnce(resolve);
+          button.click();
+        })
+    );
+    expect(requestMock).toHaveBeenCalled();
+    expect(failureMock).toHaveBeenCalledWith(error);
+  });
+
+  it("should close dialog", () => {
+    const closeMock = jest.fn();
+
+    const { getByText } = render(
+      <DeleteRole
+        role={{
+          id: "111",
+          displayName: "test project",
+          projectId: "222",
+        }}
+        accessToken="dd"
+        onClose={closeMock}
+      />
+    );
+
+    const button = getByText("No") as HTMLButtonElement;
+    act(() => button.click());
+    expect(requestMock).not.toHaveBeenCalled();
+    expect(closeMock).toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/routers/MembersRouter/components/delete-role/DeleteRole.tsx
+++ b/packages/app/src/routers/MembersRouter/components/delete-role/DeleteRole.tsx
@@ -1,0 +1,139 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *
+ * This code is for demonstration purposes and should not be considered production ready.
+ *--------------------------------------------------------------------------------------------*/
+import SvgWarning from "@itwin/itwinui-icons-react/cjs/icons/StatusWarning";
+import {
+  Button,
+  Modal,
+  ModalButtonBar,
+  ProgressRadial,
+  toaster,
+} from "@itwin/itwinui-react";
+import React from "react";
+
+import { ProjectsClient } from "../../../../api/projects/projectsClient";
+import "./DeleteRole.scss";
+
+export type DeleteRoleProps = {
+  /** Role object to delete. */
+  role: { displayName?: string; id: string; projectId: string };
+  /** Bearer access token with scope `projects:modify`. */
+  accessToken: string;
+  /** Object that configures different overrides for the API. */
+  apiOverrides?: { serverEnvironmentPrefix?: "dev" | "qa" | "" };
+  /** Callback on closed dialog. */
+  onClose?: () => void;
+  /** Callback on failed delete. */
+  onError?: (error: Error) => void;
+  /** Callback on successful delete. */
+  onSuccess?: () => void;
+  /** Object of string overrides. */
+  stringsOverrides?: {
+    /** Displayed after successful delete. */
+    successMessage?: string;
+    /** Displayed after failed delete. */
+    errorMessage?: string;
+    /** The title of the dialog. */
+    title?: string;
+    /** Main body message. */
+    bodyMessage?: string;
+    /** Confirm button string. */
+    confirmButton?: string;
+    /** Cancel button string. */
+    cancelButton?: string;
+  };
+};
+
+export function DeleteRole(props: DeleteRoleProps) {
+  const {
+    role: { id: roleId, displayName, projectId },
+    accessToken,
+    apiOverrides = { serverEnvironmentPrefix: "" },
+    onClose,
+    onError,
+    onSuccess,
+    stringsOverrides,
+  } = props;
+  const [isOpen, setIsOpen] = React.useState(true);
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const deleteRole = async () => {
+    setIsLoading(true);
+    try {
+      await new ProjectsClient(
+        apiOverrides?.serverEnvironmentPrefix ?? "",
+        accessToken
+      ).deleteProjectRole(projectId, roleId);
+      setIsLoading(false);
+      toaster.positive(
+        stringsOverrides?.successMessage ?? "Role deleted successfully."
+      );
+      onSuccess?.();
+    } catch (err) {
+      const responseError = err as Response;
+      let error = new Error();
+      if (responseError?.json) {
+        const responseBody = await responseError?.json();
+        error = { ...error, ...responseBody };
+      } else {
+        error = { ...error, ...responseError };
+      }
+      handleError(error);
+    }
+    close();
+  };
+
+  const handleError = (error: Error) => {
+    setIsLoading(false);
+    toaster.negative(
+      stringsOverrides?.errorMessage ??
+        "Could not delete a role. Please try again later."
+    );
+    onError?.(error);
+  };
+
+  const close = React.useCallback(() => {
+    setIsOpen(false);
+    onClose?.();
+  }, [onClose]);
+
+  return (
+    <>
+      <Modal
+        isOpen={isOpen}
+        style={{ maxWidth: 600 }}
+        onClose={close}
+        title={
+          <div className="idp-delete-role-title">
+            <SvgWarning className="warning-icon" />
+            {stringsOverrides?.title ??
+              `Delete role ${displayName && `'${displayName}'`}`}
+          </div>
+        }
+      >
+        {stringsOverrides?.bodyMessage ??
+          "Deleting this role will remove it for all users. Are you sure you want to delete this role?"}
+        <ModalButtonBar>
+          <Button styleType="high-visibility" onClick={deleteRole}>
+            {stringsOverrides?.confirmButton ?? "Yes"}
+          </Button>
+          <Button onClick={close}>
+            {stringsOverrides?.cancelButton ?? "No"}
+          </Button>
+        </ModalButtonBar>
+      </Modal>
+      {isLoading && <OverlaySpinner />}
+    </>
+  );
+}
+
+function OverlaySpinner() {
+  return (
+    <div className="idp-delete-role-title overlay-container">
+      <ProgressRadial indeterminate />
+    </div>
+  );
+}

--- a/packages/app/src/routers/MembersRouter/components/update-role/UpdateRole.test.tsx
+++ b/packages/app/src/routers/MembersRouter/components/update-role/UpdateRole.test.tsx
@@ -1,0 +1,165 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *
+ * This code is for demonstration purposes and should not be considered production ready.
+ *--------------------------------------------------------------------------------------------*/
+import { toaster } from "@itwin/itwinui-react";
+import { act, fireEvent, render } from "@testing-library/react";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
+import React from "react";
+
+import { UpdateRole } from "./UpdateRole";
+
+jest.mock("isomorphic-fetch", () => jest.requireActual("node-fetch"));
+const requestMock = jest.fn();
+const mockedRole = { role: { id: "dd", displayName: "name" } };
+const server = setupServer(
+  rest.patch(
+    "https://api.bentley.com/projects/:projectId/roles/:roleId",
+    (req, res, ctx) => {
+      requestMock({
+        projectId: req.params["projectId"],
+        roleId: req.params["roleId"],
+        body: req.body,
+      });
+      return res(ctx.status(200), ctx.json(mockedRole));
+    }
+  )
+);
+
+describe("UpdateRole", () => {
+  // Enable API mocking before tests.
+  beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+
+  // Reset any runtime request handlers we may add during the tests.
+  afterEach(() => {
+    jest.clearAllMocks();
+    server.resetHandlers();
+  });
+
+  // Disable API mocking after the tests are done.
+  afterAll(() => server.close());
+
+  it("should update a role", async () => {
+    const successMock = jest.fn();
+    toaster.positive = jest.fn();
+
+    const { getByText, container } = render(
+      <UpdateRole
+        accessToken="dd"
+        projectId="de47c5ad-5657-42b8-a2bc-f2b8bf84cd4b"
+        roleId="de611094-d9b9-4355-ba36-f86a5b08d4ff"
+        onSuccess={successMock}
+        initialRole={{
+          displayName: "Initial name",
+          description: "Initial description",
+        }}
+      />
+    );
+
+    const name = container.querySelector(
+      "input[name=displayName]"
+    ) as HTMLInputElement;
+    fireEvent.change(name, {
+      target: { value: "Some other name" },
+    });
+
+    const updateButton = getByText("Update");
+    await act(
+      () =>
+        new Promise((resolve) => {
+          successMock.mockImplementationOnce(resolve);
+          updateButton.click();
+        })
+    );
+    expect(requestMock).toHaveBeenCalledWith({
+      projectId: "de47c5ad-5657-42b8-a2bc-f2b8bf84cd4b",
+      roleId: "de611094-d9b9-4355-ba36-f86a5b08d4ff",
+      body: {
+        displayName: "Some other name",
+        description: "Initial description",
+        permissions: [],
+      },
+    });
+    expect(successMock).toHaveBeenCalledWith(mockedRole);
+    expect(toaster.positive).toHaveBeenCalledWith(
+      "Role updated successfully.",
+      {
+        hasCloseButton: true,
+      }
+    );
+  });
+
+  it("should show general error", async () => {
+    const errorMock = jest.fn();
+    toaster.negative = jest.fn();
+    const error = {
+      error: {
+        message: "Unauthorized",
+        code: "401",
+      },
+    };
+    server.use(
+      rest.patch(
+        "https://api.bentley.com/projects/:projectId/roles/:roleId",
+        (req, res, ctx) => {
+          requestMock({
+            projectId: req.params["projectId"],
+            roleId: req.params["roleId"],
+            body: req.body,
+          });
+          return res(ctx.status(401), ctx.json(error));
+        }
+      )
+    );
+
+    const { getByText, container } = render(
+      <UpdateRole
+        accessToken="dd"
+        projectId="de47c5ad-5657-42b8-a2bc-f2b8bf84cd4b"
+        roleId="de611094-d9b9-4355-ba36-f86a5b08d4ff"
+        onError={errorMock}
+        initialRole={{
+          displayName: "Initial name",
+          description: "Initial description",
+        }}
+      />
+    );
+
+    const name = container.querySelector(
+      "input[name=displayName]"
+    ) as HTMLInputElement;
+    fireEvent.change(name, {
+      target: { value: "Some name" },
+    });
+
+    const updateButton = getByText("Update");
+    await act(
+      () =>
+        new Promise((resolve) => {
+          errorMock.mockImplementationOnce(resolve);
+          updateButton.click();
+        })
+    );
+
+    expect(requestMock).toHaveBeenCalledWith({
+      projectId: "de47c5ad-5657-42b8-a2bc-f2b8bf84cd4b",
+      roleId: "de611094-d9b9-4355-ba36-f86a5b08d4ff",
+
+      body: {
+        displayName: "Some name",
+        description: "Initial description",
+        permissions: [],
+      },
+    });
+    expect(errorMock).toHaveBeenCalledWith(error);
+    expect(toaster.negative).toHaveBeenCalledWith(
+      "Could not update a role. Please try again later.",
+      {
+        hasCloseButton: true,
+      }
+    );
+  });
+});

--- a/packages/app/src/routers/MembersRouter/components/update-role/UpdateRole.tsx
+++ b/packages/app/src/routers/MembersRouter/components/update-role/UpdateRole.tsx
@@ -1,0 +1,148 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *
+ * This code is for demonstration purposes and should not be considered production ready.
+ *--------------------------------------------------------------------------------------------*/
+import { toaster } from "@itwin/itwinui-react";
+import React from "react";
+
+import { RoleProjectsAPI } from "../../../../api/projects/generated";
+import { ProjectsClient } from "../../../../api/projects/projectsClient";
+import {
+  BaseRole,
+  BaseRolePage,
+  PermissionOption,
+} from "../base-role/BaseRole";
+
+export type UpdateRoleProps = {
+  /** Bearer access token with scope `projects:modify`. */
+  accessToken: string;
+  /** Object that configures different overrides for the API. */
+  apiOverrides?: { serverEnvironmentPrefix?: "dev" | "qa" | "" };
+  /** Callback on canceled action. */
+  onClose?: () => void;
+  /** Callback on failed update. */
+  onError?: (
+    error: { error: { code?: string; message?: string } } | any
+  ) => void;
+  /** Callback on successful update. */
+  onSuccess?: (updatedRole: { role?: RoleProjectsAPI }) => void;
+  /** Object of string overrides. */
+  stringsOverrides?: {
+    /** Displayed after successful update. */
+    successMessage?: string;
+    /** Displayed after failed update. */
+    errorMessage?: string;
+    /** Displayed after failed create because of the duplicate name. */
+    errorMessageRoleExists?: string;
+    /** The title of the page. */
+    titleString?: string;
+    /** Role name property. */
+    displayNameString?: string;
+    /** Role description property. */
+    descriptionString?: string;
+    /** Confirm button string. */
+    confirmButton?: string;
+    /** Cancel button string. */
+    cancelButton?: string;
+    /** Error message when name is too long. */
+    displayNameTooLong?: string;
+    /** Error message when description is too long. */
+    descriptionTooLong?: string;
+  };
+  /** Role id to update. */
+  roleId: string;
+  /** Project id to update. */
+  projectId: string;
+  /** Initial iModel data. */
+  initialRole: BaseRole;
+  /** Permission options to display */
+  permissionsOptions?: PermissionOption[];
+};
+
+export function UpdateRole(props: UpdateRoleProps) {
+  const {
+    accessToken,
+    apiOverrides = { serverEnvironmentPrefix: "" },
+    onClose,
+    onError,
+    onSuccess,
+    stringsOverrides,
+    roleId,
+    projectId,
+    initialRole,
+    permissionsOptions,
+  } = props;
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const updatedStrings = {
+    successMessage: "Role updated successfully.",
+    errorMessage: "Could not update a role. Please try again later.",
+    errorMessageRoleExists: "Role with the same name already exists.",
+    titleString: "Update a role",
+    confirmButton: "Update",
+    ...stringsOverrides,
+  };
+
+  const updateRole = async (role: {
+    displayName: string;
+    description: string;
+    permissions: string[];
+  }) => {
+    setIsLoading(true);
+    try {
+      const client = new ProjectsClient(
+        apiOverrides?.serverEnvironmentPrefix ?? "",
+        accessToken
+      );
+      const updatedRole = await client.updateProjectRole(
+        projectId,
+        roleId,
+        role
+      );
+
+      setIsLoading(false);
+      toaster.positive(updatedStrings.successMessage, {
+        hasCloseButton: true,
+      });
+      onSuccess?.(updatedRole);
+    } catch (err) {
+      const responseError = err as Response;
+      let error = new Error();
+      if (responseError?.json) {
+        const responseBody = await responseError.json();
+        error = { ...error, ...responseBody };
+      } else {
+        error = { ...error, ...responseError };
+      }
+      handleError(error);
+    }
+  };
+
+  const handleError = (
+    error: { error: { code?: string; message?: string } } | any
+  ) => {
+    setIsLoading(false);
+    const errorString =
+      error?.error?.code === "RoleExists"
+        ? updatedStrings.errorMessageRoleExists
+        : updatedStrings.errorMessage;
+
+    toaster.negative(errorString, { hasCloseButton: true });
+    onError?.(error);
+  };
+
+  return (
+    <>
+      <BaseRolePage
+        stringsOverrides={updatedStrings}
+        isLoading={isLoading}
+        onActionClick={updateRole}
+        onClose={onClose}
+        initialRole={initialRole}
+        permissionsOptions={permissionsOptions}
+      />
+    </>
+  );
+}

--- a/packages/app/src/routers/MembersRouter/useRoleConfig.ts
+++ b/packages/app/src/routers/MembersRouter/useRoleConfig.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *
+ * This code is for demonstration purposes and should not be considered production ready.
+ *--------------------------------------------------------------------------------------------*/
+import React from "react";
+
+import { useApiPrefix } from "../../api/useApiPrefix";
+import { BaseRoleProps } from "./components/base-role/BaseRole";
+import { CreateRoleProps } from "./components/create-role/CreateRole";
+
+export const useRoleConfig = () => {
+  const serverEnvironmentPrefix = useApiPrefix();
+  const apiOverrides = React.useMemo<CreateRoleProps["apiOverrides"]>(
+    () => ({ serverEnvironmentPrefix }),
+    [serverEnvironmentPrefix]
+  );
+  // Using array of object in case we want to add description to the permissions
+  const permissionsOptions = React.useMemo<BaseRoleProps["permissionsOptions"]>(
+    () => [
+      {
+        permission: "administration_invite_member",
+      },
+      {
+        permission: "administration_remove_member",
+      },
+      {
+        permission: "administration_manage_roles",
+      },
+      {
+        permission: "imodels_read",
+      },
+      {
+        permission: "imodels_webview",
+      },
+      {
+        permission: "imodels_manage",
+      },
+      {
+        permission: "imodels_write",
+      },
+      {
+        permission: "imodels_delete",
+      },
+      {
+        permission: "storage_read",
+      },
+      {
+        permission: "storage_write",
+      },
+      {
+        permission: "storage_delete",
+      },
+    ],
+    []
+  );
+  return {
+    apiOverrides,
+    permissionsOptions,
+  };
+};

--- a/packages/app/src/routers/SynchronizationRouter/components/SkeletonCell.tsx
+++ b/packages/app/src/routers/SynchronizationRouter/components/SkeletonCell.tsx
@@ -9,7 +9,7 @@ import React, { PropsWithChildren } from "react";
 
 import "./SkeletonCell.scss";
 
-type SkeletonCellProps = PropsWithChildren<{
+export type SkeletonCellProps = PropsWithChildren<{
   value: any;
   row: {
     original: any;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2454,6 +2454,26 @@
   resolved "https://registry.yarnpkg.com/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.4.tgz#40e1c0ad20743fcee1604a7df2c57faf0aa1af87"
   integrity sha512-Ot53G927ykMF8cQ3/zq4foZtdk+Tt1YpX7aUTHxBU7UHNdkEiBvBfZSq+rnlUmKCJ19VatwPG4mNzvcGpBj4og==
 
+"@mswjs/cookies@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@mswjs/cookies/-/cookies-0.1.6.tgz#176f77034ab6d7373ae5c94bcbac36fee8869249"
+  integrity sha512-A53XD5TOfwhpqAmwKdPtg1dva5wrng2gH5xMvklzbd9WLTSVU953eCRa8rtrrm6G7Cy60BOGsBRN89YQK0mlKA==
+  dependencies:
+    "@types/set-cookie-parser" "^2.4.0"
+    set-cookie-parser "^2.4.6"
+
+"@mswjs/interceptors@^0.12.3":
+  version "0.12.6"
+  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.12.6.tgz#0afb7c91e14875a1127ae5181d0eae31d50a9276"
+  integrity sha512-+1jaUpKEWXP4Yed4Lj9RftroZStw0NsEvEFjwJgc941xcaiTDYyBON4kpBY32RWd7UsW/xGE1piy8qt0Gfiqyw==
+  dependencies:
+    "@open-draft/until" "^1.0.3"
+    "@xmldom/xmldom" "^0.7.2"
+    debug "^4.3.2"
+    headers-utils "^3.0.2"
+    outvariant "^1.2.0"
+    strict-event-emitter "^0.2.0"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -2482,6 +2502,11 @@
   dependencies:
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
+
+"@open-draft/until@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
+  integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
 "@popperjs/core@^2.8.3":
   version "2.9.2"
@@ -2759,6 +2784,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/cookie@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
+  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
+
 "@types/dotenv-flow@^3.0.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@types/dotenv-flow/-/dotenv-flow-3.1.0.tgz#e9ba53f95f3d40bbc0df99b206f649b2acfca0c6"
@@ -2791,6 +2821,14 @@
   dependencies:
     "@types/react" "*"
     hoist-non-react-statics "^3.3.0"
+
+"@types/inquirer@^7.3.3":
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/@types/inquirer/-/inquirer-7.3.3.tgz#92e6676efb67fa6925c69a2ee638f67a822952ac"
+  integrity sha512-HhxyLejTHMfohAuhRun4csWigAMjXTmRyiJTU1Y/I1xmggikFMkOUoMQRlFm+zQcPEGHSs3io/0FAmNZf8EymQ==
+  dependencies:
+    "@types/through" "*"
+    rxjs "^6.4.0"
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
@@ -2826,6 +2864,11 @@
   dependencies:
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
+
+"@types/js-levenshtein@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/js-levenshtein/-/js-levenshtein-1.1.0.tgz#9541eec4ad6e3ec5633270a3a2b55d981edc44a9"
+  integrity sha512-14t0v1ICYRtRVcHASzes0v/O+TIeASb8aD55cWF1PidtInhFWSXcmhzhHqGjUWf9SUq1w70cvd1cWKUULubAfQ==
 
 "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6", "@types/json-schema@^7.0.7":
   version "7.0.7"
@@ -2943,6 +2986,13 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
   integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
+"@types/set-cookie-parser@^2.4.0":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@types/set-cookie-parser/-/set-cookie-parser-2.4.1.tgz#49403d3150f6f296da8e51b3e9e7e562eaf105b4"
+  integrity sha512-N0IWe4vT1w5IOYdN9c9PNpQniHS+qe25W4tj4vfhJDJ9OkvA/YA55YUhaC+HNmMMeLlOSnBW9UMno0qlt5xu3Q==
+  dependencies:
+    "@types/node" "*"
+
 "@types/shortid@~0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/shortid/-/shortid-0.0.29.tgz#8093ee0416a6e2bf2aa6338109114b3fbffa0e9b"
@@ -2957,6 +3007,13 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
+
+"@types/through@*":
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/@types/through/-/through-0.0.30.tgz#e0e42ce77e897bd6aead6f6ea62aeb135b8a3895"
+  integrity sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.3"
@@ -3234,6 +3291,11 @@
   dependencies:
     tslib "^1.9.3"
 
+"@xmldom/xmldom@^0.7.2":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.4.tgz#93b2f9486c88b6464e97f76c9ab49b0a548fbe57"
+  integrity sha512-wdxC79cvO7PjSM34jATd/RYZuYWQ8y/R7MidZl1NYYlbpFn1+spfjkiR3ZsJfcaTs2IyslBN7VwBBJwrYKM+zw==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -3464,7 +3526,7 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-anymatch@^3.0.3, anymatch@~3.1.1:
+anymatch@^3.0.3, anymatch@~3.1.1, anymatch@~3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
   integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
@@ -4050,7 +4112,7 @@ balanced-match@^2.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-2.0.0.tgz#dc70f920d78db8b858535795867bf48f820633d9"
   integrity sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==
 
-base64-js@^1.0.2, base64-js@^1.3.0, base64-js@^1.5.1:
+base64-js@^1.0.2, base64-js@^1.3.0, base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -4106,6 +4168,15 @@ bindings@^1.5.0:
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
+
+bl@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
 
 bluebird@3.7.2, bluebird@^3.5.0, bluebird@^3.5.5:
   version "3.7.2"
@@ -4340,6 +4411,14 @@ buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
 
 builtin-status-codes@^3.0.0:
   version "3.0.0"
@@ -4653,6 +4732,21 @@ chokidar@^2.1.8:
   optionalDependencies:
     fsevents "^1.2.7"
 
+chokidar@^3.4.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
+  integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 chownr@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
@@ -4732,6 +4826,11 @@ cli-source-preview@^1.0.0:
   dependencies:
     chalk "^1.1.3"
 
+cli-spinners@^2.5.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.6.0.tgz#36c7dc98fb6a9a76bd6238ec3f77e2425627e939"
+  integrity sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==
+
 cli-truncate@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
@@ -4772,6 +4871,15 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
 clone-deep@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-0.2.4.tgz#4e73dd09e9fb971cc38670c5dced9c1896481cc6"
@@ -4798,6 +4906,11 @@ clone-regexp@^2.1.0:
   integrity sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==
   dependencies:
     is-regexp "^2.0.0"
+
+clone@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+  integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
 clone@^2.1.1:
   version "2.1.2"
@@ -5073,6 +5186,11 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+
+cookie@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 cookiejar@^2.1.2:
   version "2.1.2"
@@ -5584,7 +5702,7 @@ debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, d
   dependencies:
     ms "2.1.2"
 
-debug@4.3.2:
+debug@4.3.2, debug@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -5679,6 +5797,13 @@ default-require-extensions@^3.0.0:
   integrity sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==
   dependencies:
     strip-bom "^4.0.0"
+
+defaults@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
+  integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
+  dependencies:
+    clone "^1.0.2"
 
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
@@ -6606,7 +6731,7 @@ eventemitter3@^4.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
-events@^3.0.0:
+events@^3.0.0, events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
@@ -7355,7 +7480,7 @@ fsevents@^1.2.7:
     bindings "^1.5.0"
     nan "^2.12.1"
 
-fsevents@^2.1.2, fsevents@~2.3.1:
+fsevents@^2.1.2, fsevents@~2.3.1, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -7380,7 +7505,7 @@ gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -7458,7 +7583,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@~5.1.0:
+glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@~5.1.0, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -7581,6 +7706,11 @@ graphql@^14.4.2:
   integrity sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==
   dependencies:
     iterall "^1.2.2"
+
+graphql@^15.5.1:
+  version "15.5.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.2.tgz#efa19f8f2bf1a48eb7d5c85bf17e144ba8bb0480"
+  integrity sha512-dZjLPWNQqYv0dqV2RNbiFed0LtSp6yd4jchsDGnuhDKa9OQHJYCfovaOEvY91w9gqbYO7Se9LKDTl3xxYva/3w==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -7727,6 +7857,11 @@ he@1.2.x, he@^1.1.1, he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+headers-utils@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/headers-utils/-/headers-utils-3.0.2.tgz#dfc65feae4b0e34357308aefbcafa99c895e59ef"
+  integrity sha512-xAxZkM1dRyGV2Ou5bzMxBPNLoRCjcX+ya7KSWybQD2KwLphxsapUVK6x/02o7f4VU6GPSXch9vNY2+gkU8tYWQ==
 
 hex-color-regex@^1.1.0:
   version "1.1.0"
@@ -8086,7 +8221,7 @@ identity-obj-proxy@3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ieee754@^1.1.4:
+ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -8240,6 +8375,26 @@ inquirer@^7.0.0:
     mute-stream "0.0.8"
     run-async "^2.4.0"
     rxjs "^6.6.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+
+inquirer@^8.1.1:
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.1.2.tgz#65b204d2cd7fb63400edd925dfe428bafd422e3d"
+  integrity sha512-DHLKJwLPNgkfwNmsuEUKSejJFbkv0FMO9SMiQbjI3n5NQuCrSIBqP66ggqyz2a6t2qEolKrMjhQ3+W/xXgUQ+Q==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.1"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    ora "^5.3.0"
+    run-async "^2.4.0"
+    rxjs "^7.2.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
     through "^2.3.6"
@@ -8517,10 +8672,20 @@ is-hexadecimal@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
   integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
 
+is-interactive@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
+  integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
+
 is-negative-zero@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
   integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
+
+is-node-process@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.0.1.tgz#4fc7ac3a91e8aac58175fe0578abbc56f2831b23"
+  integrity sha512-5IcdXuf++TTNt3oGl9EBdkvndXA8gmc4bz/Y+mdEpWh3Mcn/+kOw6hI7LD5CocqJWMzeb0I0ClndRVNdEPuJXQ==
 
 is-number-object@^1.0.4:
   version "1.0.5"
@@ -9633,6 +9798,11 @@ js-base64@^2.1.9, js-base64@^2.4.5:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
   integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
+
+js-levenshtein@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -10755,6 +10925,32 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+msw@~0.32.0:
+  version "0.32.3"
+  resolved "https://registry.yarnpkg.com/msw/-/msw-0.32.3.tgz#f5bf04f49a26d3268ba374f958c2a6ee04a4f27e"
+  integrity sha512-y7rJ5UnLZmp6qXU9rg6aiXgfQ75X2MacA2Y38VilHZuMS9LRycmppceY/SfhvYFZesR0QoP4AdzCLEP0h5PJ+Q==
+  dependencies:
+    "@mswjs/cookies" "^0.1.6"
+    "@mswjs/interceptors" "^0.12.3"
+    "@open-draft/until" "^1.0.3"
+    "@types/cookie" "^0.4.1"
+    "@types/inquirer" "^7.3.3"
+    "@types/js-levenshtein" "^1.1.0"
+    chalk "^4.1.1"
+    chokidar "^3.4.2"
+    cookie "^0.4.1"
+    graphql "^15.5.1"
+    headers-utils "^3.0.2"
+    inquirer "^8.1.1"
+    is-node-process "^1.0.1"
+    js-levenshtein "^1.1.6"
+    node-fetch "^2.6.1"
+    node-match-path "^0.6.3"
+    statuses "^2.0.0"
+    strict-event-emitter "^0.2.0"
+    type-fest "^1.2.2"
+    yargs "^17.0.1"
+
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz#899f11d9686e5e05cb91b35d5f0e63b773cfc901"
@@ -10888,6 +11084,11 @@ node-libs-browser@^2.2.1:
     url "^0.11.0"
     util "^0.11.0"
     vm-browserify "^1.0.1"
+
+node-match-path@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/node-match-path/-/node-match-path-0.6.3.tgz#55dd8443d547f066937a0752dce462ea7dc27551"
+  integrity sha512-fB1reOHKLRZCJMAka28hIxCwQLxGmd7WewOCBDYKpyA1KXi68A7vaGgdZAPhY2E6SXoYt3KqYCCvXLJ+O0Fu/Q==
 
 node-modules-regexp@^1.0.0:
   version "1.0.0"
@@ -11247,6 +11448,21 @@ optionator@^0.8.1, optionator@^0.8.3:
     type-check "~0.3.2"
     word-wrap "~1.2.3"
 
+ora@^5.3.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-5.4.1.tgz#1b2678426af4ac4a509008e5e4ac9e9959db9e18"
+  integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==
+  dependencies:
+    bl "^4.1.0"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-spinners "^2.5.0"
+    is-interactive "^1.0.0"
+    is-unicode-supported "^0.1.0"
+    log-symbols "^4.1.0"
+    strip-ansi "^6.0.0"
+    wcwidth "^1.0.1"
+
 original@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/original/-/original-1.0.2.tgz#e442a61cffe1c5fd20a65f3261c26663b303f25f"
@@ -11268,6 +11484,11 @@ os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
+
+outvariant@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.2.1.tgz#e630f6cdc1dbf398ed857e36f219de4a005ccd35"
+  integrity sha512-bcILvFkvpMXh66+Ubax/inxbKRyWTUiiFIW2DWkiS79wakrLGn3Ydy+GvukadiyfZjaL6C7YhIem4EZSM282wA==
 
 p-each-series@^1.0.0:
   version "1.0.0"
@@ -13234,7 +13455,7 @@ read-pkg@^5.2.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.6.0:
+readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -13256,6 +13477,13 @@ readdirp@~3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
   integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
+  dependencies:
+    picomatch "^2.2.1"
+
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
 
@@ -13713,12 +13941,19 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@^6.6.0, rxjs@^6.6.2, rxjs@^6.6.3, rxjs@^6.6.7:
+rxjs@^6.4.0, rxjs@^6.6.0, rxjs@^6.6.2, rxjs@^6.6.3, rxjs@^6.6.7:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
+
+rxjs@^7.2.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.3.0.tgz#39fe4f3461dc1e50be1475b2b85a0a88c1e938c6"
+  integrity sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==
+  dependencies:
+    tslib "~2.1.0"
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -13980,6 +14215,11 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+set-cookie-parser@^2.4.6:
+  version "2.4.8"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz#d0da0ed388bc8f24e706a391f9c9e252a13c58b2"
+  integrity sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==
 
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"
@@ -14440,6 +14680,11 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
+statuses@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
+  integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
 stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
@@ -14483,6 +14728,13 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
+
+strict-event-emitter@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.2.0.tgz#78e2f75dc6ea502e5d8a877661065a1e2deedecd"
+  integrity sha512-zv7K2egoKwkQkZGEaH8m+i2D0XiKzx5jNsiSul6ja2IYFvil10A59Z9Y7PPAAe5OW53dQUf9CfsHKzjZzKkm1w==
+  dependencies:
+    events "^3.3.0"
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"
@@ -15301,6 +15553,11 @@ tslib@^2.0.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
+tslib@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
 tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
@@ -15356,6 +15613,11 @@ type-fest@^0.8.0, type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^1.2.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
+  integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
@@ -15850,6 +16112,13 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   integrity sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==
   dependencies:
     minimalistic-assert "^1.0.0"
+
+wcwidth@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
+  integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
+  dependencies:
+    defaults "^1.0.3"
 
 webidl-conversions@^4.0.2:
   version "4.0.2"
@@ -16365,6 +16634,11 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
   integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
 
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -16392,7 +16666,7 @@ yargs-parser@10.x:
   dependencies:
     camelcase "^4.1.0"
 
-yargs-parser@20.x:
+yargs-parser@20.x, yargs-parser@^20.2.2:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
@@ -16450,6 +16724,19 @@ yargs@^15.0.2, yargs@^15.4.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^17.0.1:
+  version "17.1.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.1.1.tgz#c2a8091564bdb196f7c0a67c1d12e5b85b8067ba"
+  integrity sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yarn@^1.22.10:
   version "1.22.10"


### PR DESCRIPTION
# Role management

Added role create/update/delete with limited set of permissions, if a role contains permissions not in the list managed by the demo portal, the whole role is locked and cant be edited. (Preventing unexpected removal of permission and be unable to set it back)
![RoleManagement](https://user-images.githubusercontent.com/1904889/132063129-c6c5c0af-643b-4b8e-8276-6232ddb6136d.gif)

Added role editing for users, directly in the users table:

![UserRoleManagement](https://user-images.githubusercontent.com/1904889/132063236-a9eaad9f-68e5-40b3-abdf-50f2d2edda9f.gif)

## Other notable changes

### Role operations
Created the role operations similar to project operations so we can eventually move to admin-component-react if needed.

### Tests
Added msw package to mock network instead of fetch request, while this caused me issue setting up, I think this is a good way of testing.