### PR TITLE
React to changes in the synchronization authorization API

### DIFF
--- a/packages/app/src/components/Synchronization/SynchronizationAPIProvider.tsx
+++ b/packages/app/src/components/Synchronization/SynchronizationAPIProvider.tsx
@@ -21,7 +21,6 @@ type SynchronizationAPIProviderProps = PropsWithChildren<{
 
 export interface SynchronizationConfig {
   isAuthorized: boolean;
-  authUrl?: string;
   login: () => void;
 }
 
@@ -93,7 +92,7 @@ export const SynchronizationAPIProvider = ({
   };
 
   return (
-    <SynchronizationContext.Provider value={{ isAuthorized, login, authUrl }}>
+    <SynchronizationContext.Provider value={{ isAuthorized, login }}>
       {children}
     </SynchronizationContext.Provider>
   );

--- a/packages/app/src/components/Synchronization/SynchronizationAPIProvider.tsx
+++ b/packages/app/src/components/Synchronization/SynchronizationAPIProvider.tsx
@@ -8,6 +8,7 @@ import { RouteComponentProps } from "@reach/router";
 import React, {
   createContext,
   PropsWithChildren,
+  useCallback,
   useEffect,
   useState,
 } from "react";
@@ -65,7 +66,7 @@ export const SynchronizationAPIProvider = ({
     }
   }, [client]);
 
-  const login = () => {
+  const login = useCallback(() => {
     if (authUrl) {
       const loginWindow = window.open(authUrl, "_blank", "popup=yes");
       const loginInterval = setInterval(() => {
@@ -89,7 +90,7 @@ export const SynchronizationAPIProvider = ({
         "Could not determine the url for synchronization authorization"
       );
     }
-  };
+  }, [authUrl, client]);
 
   return (
     <SynchronizationContext.Provider value={{ isAuthorized, login }}>

--- a/packages/app/src/components/Synchronization/SynchronizationAPIProvider.tsx
+++ b/packages/app/src/components/Synchronization/SynchronizationAPIProvider.tsx
@@ -4,9 +4,13 @@
  *
  * This code is for demonstration purposes and should not be considered production ready.
  *--------------------------------------------------------------------------------------------*/
-import { Text } from "@itwin/itwinui-react";
-import { navigate, RouteComponentProps } from "@reach/router";
-import React, { PropsWithChildren } from "react";
+import { RouteComponentProps } from "@reach/router";
+import React, {
+  createContext,
+  PropsWithChildren,
+  useEffect,
+  useState,
+} from "react";
 
 import { SynchronizationClient } from "../../api/synchronization/synchronizationClient";
 import { useApiPrefix } from "../../api/useApiPrefix";
@@ -15,34 +19,82 @@ type SynchronizationAPIProviderProps = PropsWithChildren<{
   accessToken: string;
 }>;
 
+export interface SynchronizationConfig {
+  isAuthorized: boolean;
+  authUrl?: string;
+  login: () => void;
+}
+
+export const SynchronizationContext = createContext<SynchronizationConfig>({
+  isAuthorized: false,
+  login: () => {
+    /** nop */
+  },
+});
+
 export const SynchronizationAPIProvider = ({
   accessToken,
   children,
 }: RouteComponentProps & SynchronizationAPIProviderProps) => {
   const urlPrefix = useApiPrefix();
-  const [isAuthorized, setIsAuthorized] = React.useState(false);
+  const [isAuthorized, setIsAuthorized] = useState(false);
+  const [authUrl, setAuthUrl] = useState<string>();
+  const [client, setClient] = useState<SynchronizationClient>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!accessToken) {
       return;
     }
-
-    const client = new SynchronizationClient(urlPrefix, accessToken);
-    client
-      .getAuthorization(window.location.href)
-      .then(({ authorizationInformation }) => {
-        if (
-          !authorizationInformation?.isUserAuthorized &&
-          authorizationInformation?._links?.authorizationUrl?.href
-        ) {
-          return navigate(
-            authorizationInformation._links.authorizationUrl.href
-          );
-        }
-        setIsAuthorized(true);
-      })
-      .catch(console.error);
+    setClient(new SynchronizationClient(urlPrefix, accessToken));
   }, [accessToken, urlPrefix]);
 
-  return <>{isAuthorized ? children : <Text isSkeleton={true} />}</>;
+  useEffect(() => {
+    if (client) {
+      client
+        .getAuthorization(window.location.href)
+        .then(({ authorizationInformation }) => {
+          if (
+            !authorizationInformation?.isUserAuthorized &&
+            authorizationInformation?._links?.authorizationUrl?.href
+          ) {
+            setAuthUrl(authorizationInformation._links.authorizationUrl.href);
+          } else {
+            setIsAuthorized(true);
+          }
+        })
+        .catch(console.error);
+    }
+  }, [client]);
+
+  const login = () => {
+    if (authUrl) {
+      const loginWindow = window.open(authUrl, "_blank", "popup=yes");
+      const loginInterval = setInterval(() => {
+        if (loginWindow?.closed && client) {
+          client
+            .getAuthorization(window.location.href)
+            .then(({ authorizationInformation }) => {
+              if (authorizationInformation?.isUserAuthorized) {
+                setIsAuthorized(true);
+                clearInterval(loginInterval);
+              }
+            })
+            .catch((error) => {
+              console.error(error);
+              clearInterval(loginInterval);
+            });
+        }
+      }, 2000);
+    } else {
+      console.error(
+        "Could not determine the url for synchronization authorization"
+      );
+    }
+  };
+
+  return (
+    <SynchronizationContext.Provider value={{ isAuthorized, login, authUrl }}>
+      {children}
+    </SynchronizationContext.Provider>
+  );
 };

--- a/packages/app/src/routers/SynchronizationRouter/components/ConnectionsTable.tsx
+++ b/packages/app/src/routers/SynchronizationRouter/components/ConnectionsTable.tsx
@@ -88,8 +88,11 @@ export const ConnectionsTable = ({
                     accessToken
                   );
                   const runConnection = async () => {
-                    if (!synchContext.isAuthorized) {
-                      synchContext.login();
+                    const authorized = await synchContext.login();
+                    if (!authorized) {
+                      toaster.negative(
+                        "You are not authorized to use the synchronization service. Please try again and complete the authentication process in the pop-up window that follows."
+                      );
                       return;
                     }
                     await client.runConnection(props.value ?? "");

--- a/packages/app/src/routers/SynchronizationRouter/components/ConnectionsTable.tsx
+++ b/packages/app/src/routers/SynchronizationRouter/components/ConnectionsTable.tsx
@@ -20,6 +20,7 @@ import {
 } from "../../../api/synchronization/generated";
 import { SynchronizationClient } from "../../../api/synchronization/synchronizationClient";
 import { useApiPrefix } from "../../../api/useApiPrefix";
+import { SynchronizationContext } from "../../../components/Synchronization/SynchronizationAPIProvider";
 import {
   CreateTypeFromInterface,
   pascalCaseToSentenceCase,
@@ -42,6 +43,8 @@ export const ConnectionsTable = ({
 }: ConnectionsTableProps) => {
   const urlPrefix = useApiPrefix();
   const lastRun = React.useContext(LastRunContext);
+  const synchContext = useContext(SynchronizationContext);
+
   return (
     <Table<CreateTypeFromInterface<ConnectionSynchronizationAPI>>
       data={connections}
@@ -85,6 +88,10 @@ export const ConnectionsTable = ({
                     accessToken
                   );
                   const runConnection = async () => {
+                    if (!synchContext.isAuthorized) {
+                      synchContext.login();
+                      return;
+                    }
                     await client.runConnection(props.value ?? "");
                     toaster.positive(
                       `Connection ${props.row.original.displayName} scheduled!`

--- a/packages/app/src/routers/SynchronizationRouter/components/ConnectionsTable.tsx
+++ b/packages/app/src/routers/SynchronizationRouter/components/ConnectionsTable.tsx
@@ -121,7 +121,7 @@ export const ConnectionsTable = ({
             ],
           },
         ],
-        [accessToken, lastRun, refreshCallback, urlPrefix]
+        [accessToken, lastRun, refreshCallback, urlPrefix, synchContext]
       )}
       emptyTableContent={
         "No file connected, drop file above to create new connections"

--- a/packages/app/src/routers/SynchronizationRouter/useSynchronizeFileUploader.ts
+++ b/packages/app/src/routers/SynchronizationRouter/useSynchronizeFileUploader.ts
@@ -5,12 +5,13 @@
  * This code is for demonstration purposes and should not be considered production ready.
  *--------------------------------------------------------------------------------------------*/
 import { Alert } from "@itwin/itwinui-react";
-import React, { ComponentPropsWithoutRef } from "react";
+import React, { ComponentPropsWithoutRef, useContext } from "react";
 
 import { FileUploadStorageAPI } from "../../api/storage/generated";
 import { StorageClient } from "../../api/storage/storageClient";
 import { SynchronizationClient } from "../../api/synchronization/synchronizationClient";
 import { useApiPrefix } from "../../api/useApiPrefix";
+import { SynchronizationContext } from "../../components/Synchronization/SynchronizationAPIProvider";
 import { useSynchronizeFileConflictResolver } from "./useSynchronizeFileConflictResolver";
 
 interface ConnectionFileUploaderOptions {
@@ -44,8 +45,14 @@ export const useSynchronizeFileUploader = ({
     openConflictResolutionModal,
   } = useSynchronizeFileConflictResolver(accessToken, iModelName);
 
+  const synchContext = useContext(SynchronizationContext);
+
   const uploadFiles = React.useCallback(
     async (fileList: FileList, onSuccess?: () => void) => {
+      if (!synchContext.isAuthorized) {
+        synchContext.login();
+        return;
+      }
       if (!fileList || fileList.length === 0) {
         return;
       }
@@ -188,7 +195,14 @@ export const useSynchronizeFileUploader = ({
         setState("Error");
       }
     },
-    [accessToken, iModelId, openConflictResolutionModal, projectId, urlPrefix]
+    [
+      accessToken,
+      iModelId,
+      openConflictResolutionModal,
+      projectId,
+      urlPrefix,
+      synchContext,
+    ]
   );
   const resetUploader = () => {
     setStep(0);

--- a/packages/app/src/routers/SynchronizationRouter/useSynchronizeFileUploader.ts
+++ b/packages/app/src/routers/SynchronizationRouter/useSynchronizeFileUploader.ts
@@ -4,7 +4,7 @@
  *
  * This code is for demonstration purposes and should not be considered production ready.
  *--------------------------------------------------------------------------------------------*/
-import { Alert } from "@itwin/itwinui-react";
+import { Alert, toaster } from "@itwin/itwinui-react";
 import React, { ComponentPropsWithoutRef, useContext } from "react";
 
 import { FileUploadStorageAPI } from "../../api/storage/generated";
@@ -49,8 +49,11 @@ export const useSynchronizeFileUploader = ({
 
   const uploadFiles = React.useCallback(
     async (fileList: FileList, onSuccess?: () => void) => {
-      if (!synchContext.isAuthorized) {
-        synchContext.login();
+      const authorized = await synchContext.login();
+      if (!authorized) {
+        toaster.negative(
+          "You are not authorized to use the synchronization service. Please try again and complete the authentication process in the pop-up window that follows."
+        );
         return;
       }
       if (!fileList || fileList.length === 0) {


### PR DESCRIPTION
The service will no longer redirect to our application on successful login, so launching authorization in a popup browser window instead when a user is not authorized/authenticated and they attempt an upload or synchronization.

Once the check for a redirect url parameter is moved, we should remove the parameter from our code as well. 

